### PR TITLE
Fix for issue #142

### DIFF
--- a/Figaro/src/test/scala/com/cra/figaro/test/algorithm/AbstractionTest.scala
+++ b/Figaro/src/test/scala/com/cra/figaro/test/algorithm/AbstractionTest.scala
@@ -282,14 +282,15 @@ class AbstractionTest extends WordSpec with Matchers {
         chain.addPragma(Abstraction(numBinsChain)(AbstractionScheme.RegularDiscretization))
         Values()(chain)
         val factors = ProbFactor.make(chain)
-        factors.size should equal(1) // 1 factor containing both conditional selectors
-        val List(factor1) = factors
+        factors.size should equal(2) // 2 for the conditional selectors
+        val List(factor1, factor2) = factors
         val flipVariable = Variable(flip)
         val uniform1Variable = Variable(uniform1)
         val uniform2Variable = Variable(uniform2)
         val chainVariable = Variable(chain)
-        factor1.variables should equal(List(flipVariable, chainVariable, uniform1Variable, uniform2Variable))
-        factor1.allIndices.size should equal(2 * 3 * numBinsChain * numBinsUniform)
+        factor1.variables should equal(List(flipVariable, chainVariable, uniform1Variable))
+        factor1.allIndices.size should equal(2 * numBinsChain * numBinsUniform)
+        factor2.allIndices.size should equal(2 * numBinsChain * numBinsUniform)
         val flipValues: List[Boolean] = flipVariable.range.map(_.value)
         val uniform1Values: List[Double] = uniform1Variable.range.map(_.value)
         val uniform2Values: List[Double] = uniform2Variable.range.map(_.value)
@@ -307,11 +308,17 @@ class AbstractionTest extends WordSpec with Matchers {
           i <- 0 to 1
           j <- 0 until numBinsChain
           k <- 0 until numBinsUniform
-          m <- 0 until numBinsUniform
         } {
-          if (check1(flipValues(i), chainValues(j), uniform1Values(k)) && check2(flipValues(i), chainValues(j), uniform2Values(m))) 
-          { factor1.get(List(i, j, k, m)) should equal(1.0) }
-          else { factor1.get(List(i, j, k, m)) should equal(0.0) }
+          if (check1(flipValues(i), chainValues(j), uniform1Values(k))) { factor1.get(List(i, j, k)) should equal(1.0) }
+          else { factor1.get(List(i, j, k)) should equal(0.0) }
+        }
+        for {
+          i <- 0 to 1
+          j <- 0 until numBinsChain
+          k <- 0 until numBinsUniform
+        } {
+          if (check2(flipValues(i), chainValues(j), uniform2Values(k))) { factor2.get(List(i, j, k)) should equal(1.0) }
+          else { factor2.get(List(i, j, k)) should equal(0.0) }
         }
       }
     }

--- a/Figaro/src/test/scala/com/cra/figaro/test/algorithm/factored/BPTest.scala
+++ b/Figaro/src/test/scala/com/cra/figaro/test/algorithm/factored/BPTest.scala
@@ -207,8 +207,7 @@ class BPTest extends WordSpec with Matchers {
       test(f, (b: Boolean) => b, 0.3 * 0.1 / (0.3 * 0.1 + 0.7 * 0.7), globalTol)
     }
 
-    "with a model using chain and a condition on one of the outcome elements, correctly condition the result " +
-      "but not change the belief about the parent" in {
+    "with a model using chain and a condition on one of the outcome elements, correctly condition the result but not change the belief about the parent" in {
         Universe.createNew()
         val f = Flip(0.3)
         val s1 = Select(0.1 -> 1, 0.9 -> 2)
@@ -216,7 +215,8 @@ class BPTest extends WordSpec with Matchers {
         val c = Chain(f, (b: Boolean) => if (b) s1; else s2)
 
         s1.observe(1)
-        val c_actual = .79
+        //val c_actual = .79
+        val c_actual = .70907
 
         /*
          * The "c_actual" value has been determine using Dimple to back up the results of Figaro. This exact
@@ -226,6 +226,8 @@ class BPTest extends WordSpec with Matchers {
          * that f does not change, at least it does not change significantly
          * 
          * The factor model is no longer loopy so the exact result .79 applies (Glenn)
+         * 
+         * UPDATE: We're going back to loopy since factor combining in ProbFactor is not default in BP.
          */
         test(c, (i: Int) => i == 1, c_actual, globalTol)
         test(f, (b: Boolean) => b, 0.3, 0.06)


### PR DESCRIPTION
BP now uses division to send messages to neighbors. This required
several changes outside of BP:
1. There is a new Semiring trait call DivideableSemiRing that defines
   semirings with a division operator. This is required since Boolean
   semirings cannot do divide. All double semirings have a division
   function defined, where divide by zero always produces zero.
2. In Factor, there is a new function called combination, which combines
   two factors according to a combination function. The product function i
   n factor now just calls this function with semiring.product. In BP, it
   calls combination with a division function.

This also fixed several failing tests due the reverting the combine
factors operation.
