### PR TITLE
Added evidence computation to BP.

### DIFF
--- a/Figaro/src/main/scala/com/cra/figaro/algorithm/factored/beliefpropagation/BasicFactorGraph.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/algorithm/factored/beliefpropagation/BasicFactorGraph.scala
@@ -25,7 +25,7 @@ class BasicFactorGraph(factors: List[Factor[Double]], semiring: Semiring[Double]
 
   def uniformFactor(v: List[Variable[_]]): Factor[Double] = {
     val f = new Factor[Double](v)
-    f.fillByRule((l: List[Any]) => 1.0)
+    f.fillByRule((l: List[Any]) => semiring.one)
     f
   }
 
@@ -60,7 +60,7 @@ class BasicFactorGraph(factors: List[Factor[Double]], semiring: Semiring[Double]
   def toMutableMap(m: Map[Node, Factor[Double]]): scala.collection.mutable.Map[Node, Factor[Double]] = 
     scala.collection.mutable.Map[Node, Factor[Double]]() ++ m
   
-  private[figaro] val factorsByNode = combineFactors.map(factor => (new FactorNode(factor.variables) -> factor)).toMap
+  private[figaro] val factorsByNode = combineFactors.map(factor => (new FactorNode(factor.variables) -> (factor))).toMap
 
   private[figaro] val adjacencyList = (adjacencyListFactors() ++ adjacencyListVariables()).map(m => m._1 -> toMutableMap(m._2))
 

--- a/Figaro/src/main/scala/com/cra/figaro/algorithm/factored/beliefpropagation/BeliefPropagation.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/algorithm/factored/beliefpropagation/BeliefPropagation.scala
@@ -52,7 +52,7 @@ trait BeliefPropagation[T] extends FactoredAlgorithm[T] {
    * Target elements that should not be eliminated but should be available for querying.
    */
   val targetElements: List[Element[_]]
-  
+
   /**
    * Since BP uses division to compute messages, the semiring has to have a division function defined
    */
@@ -63,15 +63,15 @@ trait BeliefPropagation[T] extends FactoredAlgorithm[T] {
    * This is overridden by DecisionVariableElimination, where it also includes utility variables.
    */
   def starterElements: List[Element[_]] = targetElements
-  
+
   /* The factor graph for this BP object */
   protected[figaro] val factorGraph: FactorGraph[T]
-  
+
   /* The beliefs associated with each node in the factor graph. The belief is the product 
    * of all messages to the node times any factor at the node
    */
   private[figaro] val beliefMap: Map[Node, Factor[T]] = Map()
-  
+
   /*
    * Returns a new message from a source node to a target node.
    */
@@ -98,7 +98,7 @@ trait BeliefPropagation[T] extends FactoredAlgorithm[T] {
     val vnFactor = factorGraph.getLastMessage(vn, fn)
 
     val total = beliefMap(fn).combination(vnFactor, semiring.divide)
-    total.marginalizeTo(semiring, vn.variable)    
+    total.marginalizeTo(semiring, vn.variable)
   }
 
   /*
@@ -108,7 +108,7 @@ trait BeliefPropagation[T] extends FactoredAlgorithm[T] {
    */
   private def getNewMessageVarToFactor(vn: VariableNode, fn: FactorNode) = {
     val fnFactor = factorGraph.getLastMessage(fn, vn)
-   
+
     val total = beliefMap(vn).combination(fnFactor, semiring.divide)
     total
   }
@@ -175,7 +175,7 @@ trait BeliefPropagation[T] extends FactoredAlgorithm[T] {
     }
     synchronousUpdate()
   }
-  
+
   override def initialize() = {
     factorGraph.getNodes.foreach(n => beliefMap.update(n, belief(n)))
   }
@@ -205,6 +205,7 @@ trait ProbabilisticBeliefPropagation extends BeliefPropagation[Double] {
   override protected[figaro] def newMessage(source: Node, target: Node): Factor[Double] = {
     val newMessage = super.newMessage(source, target)
     normalize(newMessage)
+    //newMessage
   }
 
   /**
@@ -241,7 +242,7 @@ trait ProbabilisticBeliefPropagation extends BeliefPropagation[Double] {
       factorVariable.range.zipWithIndex.map(pair => (Math.exp(factor.get(List(pair._2))), pair._1.value))
     }
   }
-  
+
   /**
    * Get the final factor for an element
    */
@@ -252,8 +253,8 @@ trait ProbabilisticBeliefPropagation extends BeliefPropagation[Double] {
         case vn: VariableNode => vn.variable == targetVar
         case _ => false
       }
-    }    
-    beliefMap(targetNode.get)   
+    }
+    beliefMap(targetNode.get)
   }
 
 }
@@ -264,7 +265,7 @@ trait ProbabilisticBeliefPropagation extends BeliefPropagation[Double] {
 trait OneTimeProbabilisticBeliefPropagation extends ProbabilisticBeliefPropagation with OneTime {
   val iterations: Int
   def run() = {
-     if (debug) {
+    if (debug) {
       val varNodes = factorGraph.getNodes.filter(_.isInstanceOf[VariableNode])
       val allVars = (Set[Variable[_]]() /: factorGraph.getNodes)((s: Set[Variable[_]], n: Node) => {
         val a = (n match {
@@ -286,13 +287,12 @@ trait OneTimeProbabilisticBeliefPropagation extends ProbabilisticBeliefPropagati
       factorGraph.getNodes.foreach { n =>
         n match {
           case fn: FactorNode => println(factorGraph.getFactorForNode(fn).toReadableString)
-          case _ => 
-        }  
+          case _ =>
+        }
       }
       println("*****************")
     }
 
-    
     for { i <- 1 to iterations } { runStep() }
   }
 }
@@ -310,7 +310,7 @@ abstract class ProbQueryBeliefPropagation(override val universe: Universe, targe
   val dependentAlgorithm: (Universe, List[NamedEvidence[_]]) => () => Double,
   depth: Int = Int.MaxValue, upperBounds: Boolean = false)
   extends ProbQueryAlgorithm
-  with ProbabilisticBeliefPropagation {
+  with ProbabilisticBeliefPropagation with ProbEvidenceBeliefPropagation {
 
   val targetElements = targets.toList
 
@@ -334,6 +334,76 @@ abstract class ProbQueryBeliefPropagation(override val universe: Universe, targe
   def computeExpectation[T](target: Element[T], function: T => Double): Double = {
     computeDistribution(target).map((pair: (Double, T)) => pair._1 * function(pair._2)).sum
   }
+}
+
+trait ProbEvidenceBeliefPropagation extends ProbabilisticBeliefPropagation {
+
+  def logFcn: (Double => Double) = semiring match {
+    case LogSumProductSemiring => (d: Double) => d
+    case SumProductSemiring => (d: Double) => if (d == semiring.zero) Double.NegativeInfinity else math.log(d)
+  }
+  def probFcn: (Double => Double) = semiring match {
+    case LogSumProductSemiring => (d: Double) => if (d == semiring.zero) 0 else math.exp(d)
+    case SumProductSemiring => (d: Double) => d
+  }
+
+  def entropy(probFactor: Factor[Double], logFactor: Factor[Double]): Double = {
+    //println("probfactor: " + probFactor.toReadableString)
+    //println("logfactor: " + logFactor.toReadableString)
+    
+    // Even though the variables in each factor are the same, the order of the vars might be different
+    val logFactorMapping = probFactor.variables.map(v => logFactor.variables.indexOf(v))
+    def remap(l: List[Int]) = l.zipWithIndex.map(s => (s._1, logFactorMapping(s._2))).sortBy(_._2).unzip._1
+    
+    val e = (0.0 /: probFactor.allIndices)((c: Double, i: List[Int]) => {
+      val p = probFcn(probFactor.get(i))
+      if (p == 0) c else c + p * logFcn(logFactor.get(remap(i)))
+    })   
+    e
+  }
+
+  /* Not true mutual information for > 2 factors, but standard for computing Bethe approximation */
+  def mutualInformation(joint: Factor[Double], marginals: Iterable[Factor[Double]]) = {
+    println(joint.toReadableString)
+    marginals foreach (f => println(f.toReadableString))
+    val newFactor = (joint /: marginals)((c: Factor[Double], n: Factor[Double]) => c.combination(n, semiring.divide))
+    val mi = (0.0 /: newFactor.allIndices)((c: Double, i: List[Int]) => {
+      val p = probFcn(joint.get(i))
+      if (p == 0) c else c + p * logFcn(newFactor.get(i))
+    })
+    mi
+  }
+
+  def computeEvidence(): Double = {
+
+    //println("Computing P(Evidence)")
+    val factorNodes = factorGraph.getNodes.filter(_.isInstanceOf[FactorNode]).toList
+    val varNodes = factorGraph.getNodes.filter(_.isInstanceOf[VariableNode]).toList
+
+    val nonZeroEvidence = factorNodes.exists(p => beliefMap(p).contents.exists(_._2 != Double.NegativeInfinity))
+    
+    if (nonZeroEvidence) {
+    //println("Computing energy")
+    val betheEnergy = -1*factorNodes.map(f => {
+      entropy(normalize(beliefMap(f)), factorGraph.getFactorForNode(f.asInstanceOf[FactorNode]))
+    }).sum
+    //println("Computing entropy")
+    val betheEntropy = {
+      val factorEntropy = -1*factorNodes.map(f => {
+        entropy(normalize(beliefMap(f)), normalize(beliefMap(f)))
+      }).sum
+      val varEntropy = varNodes.map(v => {
+        (factorGraph.getNeighbors(v).size-1)*entropy(normalize(beliefMap(v)), normalize(beliefMap(v))) 
+      }).sum
+      factorEntropy + varEntropy
+    }
+    //println("energy: " + betheEnergy + ", entropy: " + betheEntropy)
+    math.exp(-1*(betheEnergy - betheEntropy))
+    } else {
+      0.0
+    }
+  }
+
 }
 
 object BeliefPropagation {

--- a/Figaro/src/test/scala/com/cra/figaro/test/algorithm/factored/ProbEvidenceTest.scala
+++ b/Figaro/src/test/scala/com/cra/figaro/test/algorithm/factored/ProbEvidenceTest.scala
@@ -1,0 +1,112 @@
+/*
+ * ProbEvidenceTest.scala
+ * Probability of evidence computation tests.
+ * 
+ * Created By:      Avi Pfeffer (apfeffer@cra.com)
+ * Creation Date:   Jan 1, 2009
+ * 
+ * Copyright 2013 Avrom J. Pfeffer and Charles River Analytics, Inc.
+ * See http://www.cra.com or email figaro@cra.com for information.
+ * 
+ * See http://www.github.com/p2t2/figaro for a copy of the software license.
+ */
+
+package com.cra.figaro.test.algorithm.factored
+
+import org.scalatest.Matchers
+import org.scalatest.WordSpec
+import com.cra.figaro.algorithm.sampling._
+import com.cra.figaro.language._
+import com.cra.figaro.library.atomic.continuous._
+import com.cra.figaro.test._
+import com.cra.figaro.algorithm.factored.beliefpropagation.BeliefPropagation
+
+class ProbEvidenceTest extends WordSpec with Matchers {
+
+  "Computing probability of evidence" when {
+    "given a vanilla model with one condition" should {
+      "return the probability the condition is satisfied" in {
+        val universe = Universe.createNew()
+        val f = Flip(0.7)("f", universe)
+        sampleTest(0.7, List(NamedEvidence("f", Observation(true))), universe)
+      }
+    }
+
+    "given a vanilla model with two independent conditions" should {
+      "return the probability both conditions are satisfied" in {
+        val universe = Universe.createNew()
+        val f1 = Flip(0.7)("f1", universe)
+        val f2 = Flip(0.4)("f2", universe)
+        sampleTest(0.7 * 0.4, List(NamedEvidence("f1", Observation(true)), NamedEvidence("f2", Observation(true))), universe)
+      }
+    }
+
+    "given a vanilla mode with two dependent conditions" should {
+      "return the probability both conditions are jointly satisfied" in {
+        val universe = Universe.createNew()
+        val d = Select(0.2 -> 0.6, 0.8 -> 0.9)
+        val f1 = Flip(d)("f1", universe)
+        val f2 = Flip(d)("f2", universe)
+        sampleTest(0.2 * 0.6 * 0.6 + 0.8 * 0.9 * 0.9, List(NamedEvidence("f1", Observation(true)), NamedEvidence("f2", Observation(true))), universe)
+      }
+    }
+
+    "given a vanilla model with two dependent conditions and a constraint" should {
+      "return the probability both conditions are satisfied, taking into account the constraint" in {
+        val universe = Universe.createNew()
+        val d = Select(0.5 -> 0.6, 0.5 -> 0.9)("d", universe)
+        val f1 = Flip(d)("f1", universe)
+        val f2 = Flip(d)("f2", universe)
+        sampleTest(0.2 * 0.6 * 0.6*0.5 + 0.8 * 0.9 * 0.9*0.5, 
+            List(NamedEvidence("f1", Observation(true)), NamedEvidence("f2", Observation(true)), NamedEvidence("d", Constraint((d: Double) => if (d > 0.7) 0.8; else 0.2))), 
+            universe)
+      }
+    }
+
+    "given a constant whose condition is not satisfied" should {
+      "return 0" in {
+        val universe = Universe.createNew()
+        val c = Constant(8)("c", universe)
+        sampleTest(0, List(NamedEvidence("c", Observation(7))), universe)
+      }
+    }
+
+    "given a simple dist with a condition on the result" should {
+      "return the expectation over the clauses of the probability the result satisfies the condition" in {
+        val universe = Universe.createNew()
+        val d = Dist(0.3 -> Flip(0.6), 0.7 -> Flip(0.9))("d", universe)
+        sampleTest(0.3 * 0.6 + 0.7 * 0.9, List(NamedEvidence("d", Observation(true))), universe)
+      }
+    }
+
+    "given a complex dist with a condition on the result" should {
+      "return the expectation over the clauses of the probability the result satisfies the condition" in {
+        val universe = Universe.createNew()
+        val p1 = Select(0.2 -> 0.4, 0.8 -> 0.6)
+        val p2 = Constant(0.4)
+        val d = Dist(p1 -> Flip(0.6), p2 -> Flip(0.9))("d", universe)
+        sampleTest(0.2 * (0.5 * 0.6 + 0.5 * 0.9) + 0.8 * (0.6 * 0.6 + 0.4 * 0.9), List(NamedEvidence("d", Observation(true))), universe)
+      }
+    }
+
+
+    "given a caching chain with a condition on the result" should {
+      "return the expectation over the parent of the probability the result satisfies the condition" in {
+        val universe = Universe.createNew()
+        val p1 = Select(0.4 -> 0.3, 0.6 -> 0.9)
+        val c = CachingChain(p1, (d: Double) => if (d < 0.4) Flip(0.3); else Flip(0.8))("c", universe)
+        sampleTest(0.4 * 0.3 + 0.6 * 0.8, List(NamedEvidence("c", Observation(true))), universe)
+      }
+    }
+
+  }
+
+ 
+
+  def sampleTest(prob: Double, evidence: List[NamedEvidence[_]], universe: Universe) {
+    universe.assertEvidence(evidence)
+    val alg = BeliefPropagation(100, universe.activeElements.toList:_*)
+    alg.start
+    alg.computeEvidence should be(prob +- 0.01)
+  }
+}


### PR DESCRIPTION
Note that this does not implement the ProbEvidenceAlgorithm interface
yet. Some more work is needed to enable this. Currently you can get the
prob evidence from BP after running the algorithm and called
computeEvidence
