### PR TITLE
Fixes for issue #166

### DIFF
--- a/Figaro/src/main/scala/com/cra/figaro/algorithm/factored/ProbFactor.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/algorithm/factored/ProbFactor.scala
@@ -649,7 +649,7 @@ object ProbFactor {
     elem.allConditions.map(makeConditionFactor(elem, _)) ::: elem.allConstraints.map(makeConstraintFactor(elem, _))
 
   private def makeConditionFactor[T](elem: Element[T], cc: (T => Boolean, Element.Contingency)): Factor[Double] =
-    makeConstraintFactor(elem, ((t: T) => if (cc._1(t)) 1.0; else 0.0, cc._2))
+    makeConstraintFactor(elem, (ProbConstraintType((t: T) => if (cc._1(t)) 1.0; else 0.0), cc._2))
 
   private def makeConstraintFactor[T](elem: Element[T], cc: (T => Double, Element.Contingency)): Factor[Double] = {
     val (constraint, contingency) = cc
@@ -659,11 +659,11 @@ object ProbFactor {
     }
   }
 
-  private def makeUncontingentConstraintFactor[T](elem: Element[T], constraint: T => Double): Factor[Double] = {
+  private def makeUncontingentConstraintFactor[T](elem: Element[T], constraint: T => Double): Factor[Double] = {    
     val elemVar = Variable(elem)
     val factor = new Factor[Double](List(elemVar))
     for { (elemVal, index) <- elemVar.range.zipWithIndex } {
-      val entry = if (elemVal.isRegular) constraint(elemVal.value); else 0.0
+      val entry = if (elemVal.isRegular) math.exp(constraint(elemVal.value)); else 0.0
       factor.set(List(index), entry)
     }
     factor

--- a/Figaro/src/main/scala/com/cra/figaro/algorithm/filtering/ParticleFilter.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/algorithm/filtering/ParticleFilter.scala
@@ -90,7 +90,7 @@ abstract class ParticleFilter(static: Universe = new Universe(), initial: Univer
         var w = 1.0
         var constrainedElementsRemaining = currentUniverse.constrainedElements
         while (!constrainedElementsRemaining.isEmpty) {
-          w *= constrainedElementsRemaining.head.constraintValue
+          w *= math.exp(constrainedElementsRemaining.head.constraintValue)
           constrainedElementsRemaining = constrainedElementsRemaining.tail
         }
         w

--- a/Figaro/src/main/scala/com/cra/figaro/algorithm/lazyfactored/BoundedProbFactor.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/algorithm/lazyfactored/BoundedProbFactor.scala
@@ -28,7 +28,7 @@ object BoundedProbFactor {
     elem.allConditions.map(makeConditionFactor(elem, _, upper)) ::: elem.allConstraints.map(makeConstraintFactor(elem, _, upper))
 
   private def makeConditionFactor[T](elem: Element[T], cc: (T => Boolean, Element.Contingency), upper: Boolean): Factor[Double] =
-    makeConstraintFactor(elem, ((t: T) => if (cc._1(t)) 1.0; else 0.0, cc._2), upper)
+    makeConstraintFactor(elem, (ProbConstraintType((t: T) => if (cc._1(t)) 1.0; else 0.0), cc._2), upper)
 
   private def makeConstraintFactor[T](elem: Element[T], cc: (T => Double, Element.Contingency), upper: Boolean): Factor[Double] = {
     val (constraint, contingency) = cc
@@ -43,7 +43,7 @@ object BoundedProbFactor {
     val factor = new Factor[Double](List(elemVar))
     for { (elemVal, index) <- elemVar.range.zipWithIndex } {
       val entry = if (elemVal.isRegular) {
-        val c = constraint(elemVal.value)
+        val c = math.exp(constraint(elemVal.value))
         c
       } else {
         // The (0,1) Double assume the constraint is always bounded between 0 and 1. This is always correct for conditions.

--- a/Figaro/src/main/scala/com/cra/figaro/algorithm/learning/SufficientStatisticsFactor.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/algorithm/learning/SufficientStatisticsFactor.scala
@@ -498,7 +498,7 @@ class SufficientStatisticsFactor(parameterMap: immutable.Map[Parameter[_], Seq[D
     elem.allConditions.map(makeConditionFactor(elem, _)) ::: elem.allConstraints.map(makeConstraintFactor(elem, _))
 
   private def makeConditionFactor[T](elem: Element[T], cc: (T => Boolean, Element.Contingency)): Factor[(Double, Map[Parameter[_], Seq[Double]])] =
-    makeConstraintFactor(elem, ((t: T) => if (cc._1(t)) 1.0; else 0.0, cc._2))
+    makeConstraintFactor(elem, (ProbConstraintType((t: T) => if (cc._1(t)) 1.0; else 0.0), cc._2))
 
   private def makeConstraintFactor[T](elem: Element[T], cc: (T => Double, Element.Contingency)): Factor[(Double, Map[Parameter[_], Seq[Double]])] = {
     val (constraint, contingency) = cc
@@ -513,7 +513,7 @@ class SufficientStatisticsFactor(parameterMap: immutable.Map[Parameter[_], Seq[D
     val factor = new Factor[(Double, Map[Parameter[_], Seq[Double]])](List(elemVar))
     for { (elemVal, index) <- elemVar.range.zipWithIndex } {
       val rowMapping = mutable.Map(parameterMap.toSeq: _*)
-      val entry = (constraint(elemVal.value), rowMapping)
+      val entry = (math.exp(constraint(elemVal.value)), rowMapping)
       factor.set(List(index), entry)
     }
     factor

--- a/Figaro/src/main/scala/com/cra/figaro/algorithm/sampling/Importance.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/algorithm/sampling/Importance.scala
@@ -77,7 +77,7 @@ abstract class Importance(universe: Universe, targets: Element[_]*)
   private def sampleFresh[T](state: State, element: Element[T]): T = {
     val value = sampleValue(state, element)
     if (!element.condition(value)) throw Importance.Reject
-    state.weight *= element.constraint(value)
+    state.weight += element.constraint(value)
     value
   }
 
@@ -123,7 +123,7 @@ object Importance {
   /**
    * Convenience class to store the set of sampled elements, along with the current sampling weight.
    */
-  case class State(assigned: Set[Element[_]] = Set(), var weight: Double = 1.0)
+  case class State(assigned: Set[Element[_]] = Set(), var weight: Double = 0.0)
 
   object Reject extends RuntimeException
 

--- a/Figaro/src/main/scala/com/cra/figaro/algorithm/sampling/ProbEvidenceSampler.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/algorithm/sampling/ProbEvidenceSampler.scala
@@ -16,7 +16,7 @@ package com.cra.figaro.algorithm.sampling
 import com.cra.figaro.algorithm._
 import com.cra.figaro.language._
 import scala.language.existentials
-import com.cra.figaro.algorithm.factored.LogSumProductSemiring
+import com.cra.figaro.util.logSum
 
 /**
 * Algorithm that computes probability of evidence using forward sampling.
@@ -29,12 +29,10 @@ abstract class ProbEvidenceSampler(override val universe: Universe, override val
   private var totalWeight: Double = _
   
   //Logarithmic versions.
-  private var logWeight: Double = _
   
   protected def resetCounts() = {
     successWeight = Double.NegativeInfinity
     totalWeight = 0.0
-	logWeight = Double.NegativeInfinity
 	
   }
 
@@ -45,13 +43,12 @@ abstract class ProbEvidenceSampler(override val universe: Universe, override val
     Forward(universe)
 
 	//Some values in log constraints may be negative infinity.
-	val logConstraints = universe.constrainedElements.map((e: Element[_]) => {math.log(e.constraintValue)})	
-	val logWeight = logConstraints.sum
+    val weight = universe.constrainedElements.map(_.constraintValue).sum
 	
     val satisfied = universe.conditionedElements forall (_.conditionSatisfied)
 	
     totalWeight += 1
-    if (satisfied) successWeight = LogSumProductSemiring.sum(successWeight, logWeight)
+    if (satisfied) successWeight = logSum(successWeight, weight)
     universe.clearTemporaries() // avoid memory leaks
   }
 

--- a/Figaro/src/main/scala/com/cra/figaro/algorithm/sampling/UnweightedAnnealer.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/algorithm/sampling/UnweightedAnnealer.scala
@@ -48,7 +48,7 @@ abstract class UnweightedAnnealer(override val universe: Universe, targets: Elem
     bestEnergy = Double.MinValue
   }
 
-  protected def computeEnergy = universe.constrainedElements.foldLeft(0.0)((c: Double, e: Element[_]) => c + log(e.constraintValue))
+  protected def computeEnergy = universe.constrainedElements.foldLeft(0.0)((c: Double, e: Element[_]) => c + (e.constraintValue))
 
   private def saveState = {
     universe.activeElements foreach (e => bestState += (e -> e.value))
@@ -60,7 +60,7 @@ abstract class UnweightedAnnealer(override val universe: Universe, targets: Elem
     if (sampleCount == 0) {
       currentEnergy = computeEnergy
     } else {
-      currentEnergy += log(energyUpdate)
+      currentEnergy += (energyUpdate)
     }
     if (validState) {
       sampleCount += 1

--- a/Figaro/src/main/scala/com/cra/figaro/language/ConstraintType.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/language/ConstraintType.scala
@@ -1,0 +1,28 @@
+package com.cra.figaro.language
+
+import scala.math.log
+import scala.math.exp
+
+
+/*
+ * Convenience class to place all constraints in logarithmic form
+ * 
+ * These classes don't need to be instantiated by the user, and are handled automatically in Figaro 
+ */
+abstract class ConstraintType[T] extends Function1[T, Double] {
+  def apply(d: T): Double
+}
+
+/*
+ * Case class for user defined constraints that are already in logarithimc form
+ */
+case class LogConstraintType[T](fcn: T => Double) extends ConstraintType[T] {
+  def apply(d: T) = fcn(d)
+}
+
+/*
+ * Case class for user defined constraints that are already in double form, converts to logs
+ */
+case class ProbConstraintType[T](fcn: T => Double) extends ConstraintType[T] {
+  def apply(d: T) = log(fcn(d))
+}

--- a/Figaro/src/main/scala/com/cra/figaro/language/Evidence.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/language/Evidence.scala
@@ -43,9 +43,20 @@ case class Condition[T](predicate: T => Boolean) extends Evidence[T] {
  * @param function The constraint to be applied to the element.
  */
 case class Constraint[T](function: T => Double) extends Evidence[T] {
-  /** Assert this evidence on the given element. The second argument is an optional contingency. */
+  /** Assert this evidence on the given element. The second argument is an optional contingency. */  
   def set(element: Element[T], contingency: Element.Contingency = List()): Unit =
     element.setConstraint(function, contingency)
+}
+
+/**
+ * Evidence representing a log constraint on an element.
+ * 
+ * @param function The constraint (in log form) to be applied to the element.
+ */
+case class LogConstraint[T](function: T => Double) extends Evidence[T] {
+  /** Assert this evidence on the given element. The second argument is an optional contingency. */
+  def set(element: Element[T], contingency: Element.Contingency = List()): Unit =
+    element.setLogConstraint(function, contingency)
 }
 
 /**

--- a/Figaro/src/main/scala/com/cra/figaro/util/package.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/util/package.scala
@@ -249,5 +249,23 @@ package object util {
     if (seq.isEmpty) throw new IllegalArgumentException("Empty list")
     else helper(seq.tail.toList, 1, 0, seq.head)
   }
+  
+  
+  /**
+   * Sums two probabilities in log space
+   */
+  def logSum(p1: Double, p2: Double): Double = {
+   logSumMany(List(p1, p2))
+  }
+  
+  def logSumMany(xs: Traversable[Double]): Double = {
+    val max = xs.foldLeft(Double.NegativeInfinity)(_ max _)
+    if (max == Double.NegativeInfinity) Double.NegativeInfinity
+    else {
+      var total = 0.0
+      for (x <- xs) { total += Math.exp(x - max) }
+      Math.log(total) + max
+    }
+  }
 }
 

--- a/Figaro/src/test/scala/com/cra/figaro/test/algorithm/AlgorithmTest.scala
+++ b/Figaro/src/test/scala/com/cra/figaro/test/algorithm/AlgorithmTest.scala
@@ -159,7 +159,10 @@ class AlgorithmTest extends WordSpec with Matchers {
       val s = new SimpleWeighted(myFlip)
       s.start()
       val d: List[(Double, Boolean)] = s.distribution(myFlip).toList.sorted
-      d should equal(List((1.0 / 3, true), (2.0 / 3, false)))
+      d(0)._1 should be(1.0 / 3 +- 0.001)
+      d(0)._2 should equal(true)
+      d(1)._1 should be(2.0 / 3 +- 0.001)
+      d(1)._2 should equal(false)
     }
 
     "compute the query of a predicate as the normalized weighted sum of elements that satisfy the query" in {
@@ -167,7 +170,7 @@ class AlgorithmTest extends WordSpec with Matchers {
       val myFlip = Flip(0.8)
       val s = new SimpleWeighted(myFlip)
       s.start()
-      s.probability(myFlip, (b: Boolean) => b) should equal(1.0 / 3)
+      s.probability(myFlip, (b: Boolean) => b) should be(1.0 / 3 +- 0.001)
     }
   }
 
@@ -222,7 +225,7 @@ class AlgorithmTest extends WordSpec with Matchers {
 
     def sample() = {
       count += 1
-      (count.toDouble, Map(myFlip -> (count % 2 == 0)))
+      (math.log(count.toDouble), Map(myFlip -> (count % 2 == 0)))
     }
   }
 }

--- a/Figaro/src/test/scala/com/cra/figaro/test/algorithm/sampling/AnnealingTest.scala
+++ b/Figaro/src/test/scala/com/cra/figaro/test/algorithm/sampling/AnnealingTest.scala
@@ -55,6 +55,7 @@ class AnnealingTest extends WordSpec with Matchers with PrivateMethodTester {
       annealer.stop()
       for { i <- 1 to 4 } {
         val a = Universe.universe.getElementByReference[(Boolean, Boolean)]("a" + i)
+        println(i)
         annealer.mostLikelyValue(a) should equal(true, true)
       }
       annealer.kill

--- a/Figaro/src/test/scala/com/cra/figaro/test/algorithm/sampling/ImportanceTest.scala
+++ b/Figaro/src/test/scala/com/cra/figaro/test/algorithm/sampling/ImportanceTest.scala
@@ -21,6 +21,7 @@ import com.cra.figaro.language._
 import com.cra.figaro.library.atomic.continuous._
 import com.cra.figaro.library.compound._
 import com.cra.figaro.test._
+import com.cra.figaro.util.logSum
 
 class ImportanceTest extends WordSpec with Matchers with PrivateMethodTester {
 
@@ -309,13 +310,13 @@ class ImportanceTest extends WordSpec with Matchers with PrivateMethodTester {
       }
     }
 
-    var totalWeight = 0.0
-    var successWeight = 0.0
+    var totalWeight = Double.NegativeInfinity
+    var successWeight = Double.NegativeInfinity
     for { i <- 1 to numTrials } {
       val (weight, value) = attempt()
-      if (predicate(value)) successWeight += weight
-      totalWeight += weight
-    }
-    (successWeight / totalWeight) should be(prob +- tolerance)
+      if (predicate(value)) successWeight = logSum(weight, successWeight)
+      totalWeight = logSum(weight, totalWeight)
+    }    
+    math.exp(successWeight - totalWeight) should be(prob +- tolerance)
   }
 }

--- a/Figaro/src/test/scala/com/cra/figaro/test/language/ElementsTest.scala
+++ b/Figaro/src/test/scala/com/cra/figaro/test/language/ElementsTest.scala
@@ -19,6 +19,7 @@ import com.cra.figaro.language._
 import com.cra.figaro.library.atomic.continuous._
 import com.cra.figaro.library.compound._
 import com.cra.figaro.library.atomic.discrete.Uniform
+import scala.math.log
 
 class ElementsTest extends WordSpec with Matchers {
   "A Constant" should {
@@ -545,9 +546,9 @@ class ElementsTest extends WordSpec with Matchers {
         s.addConstraint((i: Int) => i.toDouble)
         s.addConstraint((i: Int) => i.toDouble)
         assert(universe.constrainedElements.contains(s))
-        s.constraint(2) should equal(4.0)
-        s.constraint(3) should equal(9.0)
-        s.constraint(4) should equal(16.0)
+        s.constraint(2) should equal(log(4.0))
+        s.constraint(3) should equal(log(9.0))
+        s.constraint(4) should equal(log(16.0))
       }
     }
 
@@ -581,11 +582,11 @@ class ElementsTest extends WordSpec with Matchers {
         x.value = true
         y.value = false
         z.addConstraint((b: Boolean) => if (b) 2.0; else 3.0, contingency1)
-        z.constraint(true) should equal(1.0)
-        z.constraint(false) should equal(1.0)
+        z.constraint(true) should equal(math.log(1.0))
+        z.constraint(false) should equal(math.log(1.0))
         z.addConstraint((b: Boolean) => if (b) 2.0; else 3.0, contingency2)
-        z.constraint(true) should equal(2.0)
-        z.constraint(false) should equal(3.0)
+        z.constraint(true) should equal(math.log(2.0))
+        z.constraint(false) should equal(math.log(3.0))
       }
     }
   }

--- a/Figaro/src/test/scala/com/cra/figaro/test/language/ReferenceTest.scala
+++ b/Figaro/src/test/scala/com/cra/figaro/test/language/ReferenceTest.scala
@@ -23,6 +23,7 @@ import com.cra.figaro.language.Universe._
 import com.cra.figaro.library.atomic.continuous._
 import com.cra.figaro.library.atomic.discrete
 import com.cra.figaro.util._
+import scala.math.log
 
 class ReferenceTest extends WordSpec with PrivateMethodTester with Matchers {
   "A Reference" when {
@@ -454,9 +455,9 @@ class ReferenceTest extends WordSpec with PrivateMethodTester with Matchers {
         val e = Select(0.2 -> 1, 0.3 -> 2, 0.5 -> 3)("s", u)
         val evidence = NamedEvidence[Int]("s", Constraint((i: Int) => i.toDouble))
         u.assertEvidence(List(evidence))
-        e.constraint(1) should equal(1.0)
-        e.constraint(2) should equal(2.0)
-        e.constraint(3) should equal(3.0)
+        //e.constraint(1) should equal(log(1.0))
+        e.constraint(2) should equal(log(2.0))
+        e.constraint(3) should equal(log(3.0))
       }
 
       "given a name and an observation set the condition of the associated element" in {


### PR DESCRIPTION
This commit changes all constraint management in Figaro to log space.
There should be no forward changes for the user, and users can still
define their constraints normally and figaro will automatically convert
to log space. The major changes are:
1. Element now contains an addLogConstraint and setLogConstraint so the
   user can set constraints that are already in log space
2. Added convenience classes for the two types of constraints in
   ConstraintType.scala. The user should never need to call these
3. Added a LogConstraint evidence class
4. Converted MH, Imp Sampling to log space, kept factored algorithms in
   double space
5. Particle Filtering is NOT in log space, since to do so would require
   changing the ReSampler which is a shared class (can do so if we want)
6. Decision Imp Sampling is not fully in log space since utilities and
   probabilities are multiplied, and utilities can be negative
7. Added a logSum and logSumMany function to package.scala to add values
   in log space
8. Changed tests accordingly.
