### PR TITLE
Fix warnings (all deprecations) in tests

### DIFF
--- a/Figaro/src/test/scala/com/cra/figaro/test/algorithm/AlgorithmTest.scala
+++ b/Figaro/src/test/scala/com/cra/figaro/test/algorithm/AlgorithmTest.scala
@@ -29,10 +29,10 @@ class AlgorithmTest extends WordSpec with Matchers {
       Universe.createNew()
       val c = Flip(0.3)
       val a = new SimpleAlgorithm(c)
-      evaluating { a.distribution(c) } should produce[AlgorithmInactiveException]
-      evaluating { a.expectation(c, (b: Boolean) => 1.0) } should produce[AlgorithmInactiveException]
-      evaluating { a.probability(c, (b: Boolean) => true) } should produce[AlgorithmInactiveException]
-      evaluating { a.probability(c, true) } should produce[AlgorithmInactiveException]
+      an [AlgorithmInactiveException] should be thrownBy { a.distribution(c) } 
+      an [AlgorithmInactiveException] should be thrownBy { a.expectation(c, (b: Boolean) => 1.0) }
+      an [AlgorithmInactiveException] should be thrownBy  { a.probability(c, (b: Boolean) => true) }
+      an [AlgorithmInactiveException] should be thrownBy  { a.probability(c, true) }
     }
 
     "allow queries after starting, stopping, and resuming" in {
@@ -62,10 +62,10 @@ class AlgorithmTest extends WordSpec with Matchers {
       val a = new SimpleAlgorithm(c)
       a.start()
       a.kill()
-      evaluating { a.distribution(c) } should produce[AlgorithmInactiveException]
-      evaluating { a.expectation(c, (b: Boolean) => 1.0) } should produce[AlgorithmInactiveException]
-      evaluating { a.probability(c, (b: Boolean) => true) } should produce[AlgorithmInactiveException]
-      evaluating { a.probability(c, true) } should produce[AlgorithmInactiveException]
+      an [AlgorithmInactiveException] should be thrownBy  { a.distribution(c) }
+      an [AlgorithmInactiveException] should be thrownBy  { a.expectation(c, (b: Boolean) => 1.0) }
+      an [AlgorithmInactiveException] should be thrownBy  { a.probability(c, (b: Boolean) => true) }
+      an [AlgorithmInactiveException] should be thrownBy  { a.probability(c, true) } 
     }
 
     "not allow start after starting" in {
@@ -73,16 +73,16 @@ class AlgorithmTest extends WordSpec with Matchers {
       val c = Flip(0.3)
       val a = new SimpleAlgorithm(c)
       a.start()
-      evaluating { a.start() } should produce[AlgorithmActiveException]
+      an [AlgorithmActiveException] should be thrownBy  { a.start() }
     }
 
     "not allow stop, resume, or kill before starting" in {
       Universe.createNew()
       val c = Flip(0.3)
       val a = new SimpleAlgorithm(c)
-      evaluating { a.stop() } should produce[AlgorithmInactiveException]
-      evaluating { a.resume() } should produce[AlgorithmInactiveException]
-      evaluating { a.kill() } should produce[AlgorithmInactiveException]
+      an [AlgorithmInactiveException] should be thrownBy  { a.stop() }
+      an [AlgorithmInactiveException] should be thrownBy  { a.resume() }
+      an [AlgorithmInactiveException] should be thrownBy  { a.kill() }
     }
 
     "allow start after starting and killing" in {

--- a/Figaro/src/test/scala/com/cra/figaro/test/algorithm/decision/DecisionImportanceTest.scala
+++ b/Figaro/src/test/scala/com/cra/figaro/test/algorithm/decision/DecisionImportanceTest.scala
@@ -41,7 +41,7 @@ class DecisionImportanceTest extends WordSpec with Matchers {
         val r1 = Flip(0.5)
         val d1 = Decision[Boolean, Boolean](r1, List(true, false))
         val u1 = If(d1, Constant(true), Constant(false))
-        evaluating { DecisionImportance(2000, List(u1), d1) } should produce[IllegalArgumentException]
+        an [IllegalArgumentException] should be thrownBy { DecisionImportance(2000, List(u1), d1) } 
       }
 
     }
@@ -49,7 +49,7 @@ class DecisionImportanceTest extends WordSpec with Matchers {
     "Running Importance Sampling with discrete decisons" should {
       "throw ParentValueNotFoundException if decision not encountered" in {
         val d = DecisionDiscrete((e1: List[Element[Double]], e2: Decision[Int, Boolean]) => DecisionImportance(10000, e1, e2))
-        evaluating { d._1.getPolicy(1) } should produce[ParentValueNotFoundException]
+        an [ParentValueNotFoundException] should be thrownBy { d._1.getPolicy(1) } 
       }
 
       "produce the correct strategy with discrete strategies" in {

--- a/Figaro/src/test/scala/com/cra/figaro/test/algorithm/decision/DecisionMetropolisHastingsTest.scala
+++ b/Figaro/src/test/scala/com/cra/figaro/test/algorithm/decision/DecisionMetropolisHastingsTest.scala
@@ -40,7 +40,7 @@ class DecisionMetropolisHastingsTest extends WordSpec with Matchers {
         val r1 = Flip(0.5)
         val d1 = Decision[Boolean, Boolean](r1, List(true, false))
         val u1 = If(d1, Constant(true), Constant(false))
-        evaluating { DecisionMetropolisHastings(2000, ProposalScheme.default, List(u1), d1) } should produce[IllegalArgumentException]
+        an [IllegalArgumentException] should be thrownBy { DecisionMetropolisHastings(2000, ProposalScheme.default, List(u1), d1) } 
       }
     }
 
@@ -48,7 +48,7 @@ class DecisionMetropolisHastingsTest extends WordSpec with Matchers {
       "throw ParentValueNotFoundException if decision not encountered" in {
         val d = DecisionDiscrete((e1: List[Element[Double]], e2: Decision[Int, Boolean]) =>
           DecisionMetropolisHastings(5000, ProposalScheme.default, 5000, e1, e2))
-        evaluating { d._1.getPolicy(1) } should produce[ParentValueNotFoundException]
+        an [ParentValueNotFoundException] should be thrownBy { d._1.getPolicy(1) } 
       }
 
       "produce the correct strategy with discrete strategies" in {

--- a/Figaro/src/test/scala/com/cra/figaro/test/algorithm/decision/DecisionVETest.scala
+++ b/Figaro/src/test/scala/com/cra/figaro/test/algorithm/decision/DecisionVETest.scala
@@ -41,7 +41,7 @@ class DecisionVETest extends WordSpec with Matchers {
         val r1 = Flip(0.5)
         val d1 = CachingDecision[Boolean, Boolean](r1, List(true, false))
         val u1 = If(d1, Constant(true), Constant(false))
-        evaluating { DecisionVariableElimination(List(u1), d1) } should produce[IllegalArgumentException]
+        an [IllegalArgumentException] should be thrownBy { DecisionVariableElimination(List(u1), d1) } 
       }
     }
 

--- a/Figaro/src/test/scala/com/cra/figaro/test/algorithm/factored/BPTest.scala
+++ b/Figaro/src/test/scala/com/cra/figaro/test/algorithm/factored/BPTest.scala
@@ -286,7 +286,7 @@ class BPTest extends WordSpec with Matchers {
       val f = Flip(0.5)
       val x = NonCachingChain(f, (b: Boolean) => if (b) Constant(0) else Constant(1))
       val ve = BeliefPropagation(50)
-      evaluating { ve.getNeededElements(List(x), Int.MaxValue) } should produce[UnsupportedAlgorithmException]
+      an [UnsupportedAlgorithmException] should be thrownBy { ve.getNeededElements(List(x), Int.MaxValue) } 
     }
   }
 

--- a/Figaro/src/test/scala/com/cra/figaro/test/algorithm/factored/VETest.scala
+++ b/Figaro/src/test/scala/com/cra/figaro/test/algorithm/factored/VETest.scala
@@ -448,7 +448,7 @@ class VETest extends WordSpec with Matchers {
       val f = Flip(0.5)
       val x = NonCachingChain(f, (b: Boolean) => if (b) Constant(0) else Constant(1))
       val ve = VariableElimination(x)
-      evaluating { ve.getNeededElements(List(x), Int.MaxValue) } should produce[UnsupportedAlgorithmException]
+      an [UnsupportedAlgorithmException] should be thrownBy { ve.getNeededElements(List(x), Int.MaxValue) } 
     }
   }
 

--- a/Figaro/src/test/scala/com/cra/figaro/test/language/ReferenceTest.scala
+++ b/Figaro/src/test/scala/com/cra/figaro/test/language/ReferenceTest.scala
@@ -44,7 +44,7 @@ class ReferenceTest extends WordSpec with PrivateMethodTester with Matchers {
 
     "created from a string with only periods" should {
       "throw IllegalArgumentException" in {
-        evaluating { val r: Reference[Int] = "..." } should produce[IllegalArgumentException]
+        an [IllegalArgumentException] should be thrownBy { val r: Reference[Int] = "..." } 
       }
     }
   }
@@ -69,14 +69,14 @@ class ReferenceTest extends WordSpec with PrivateMethodTester with Matchers {
 
       "throw NoSuchElementException when given a reference in which a name does not exist" in {
         createNew()
-        evaluating { universe.getElementByReference("g.u") } should produce[NoSuchElementException]
+        an [NoSuchElementException] should be thrownBy { universe.getElementByReference("g.u") } 
       }
 
       "throw NoSuchElementException when given a reference in which an intermediate name does not refer " +
         "to an element collection" in {
           createNew()
           val u = Uniform(0.0, 1.0)
-          evaluating { universe.getElementByReference("u.f") } should produce[NoSuchElementException]
+          an [NoSuchElementException] should be thrownBy  { universe.getElementByReference("u.f") }
         }
     }
     

--- a/Figaro/src/test/scala/com/cra/figaro/test/language/UniverseTest.scala
+++ b/Figaro/src/test/scala/com/cra/figaro/test/language/UniverseTest.scala
@@ -250,7 +250,7 @@ class UniverseTest extends WordSpec with Matchers {
       "throw IllegalArgumentException" in {
         createNew()
         val e = Constant(8)
-        evaluating { e.activate() } should produce[IllegalArgumentException]
+        an [IllegalArgumentException] should be thrownBy { e.activate() } 
       }
     }
 
@@ -259,7 +259,7 @@ class UniverseTest extends WordSpec with Matchers {
         createNew()
         val e = Constant(8)
         e.deactivate()
-        evaluating { e.deactivate() } should produce[IllegalArgumentException]
+        an [IllegalArgumentException] should be thrownBy { e.deactivate() } 
       }
     }
 
@@ -268,7 +268,7 @@ class UniverseTest extends WordSpec with Matchers {
         createNew()
         val e1 = Constant(8)
         e1.deactivate()
-        evaluating { universe.context(e1) } should produce[NoSuchElementException]
+        an [NoSuchElementException] should be thrownBy { universe.context(e1) } 
       }
     }
 
@@ -277,7 +277,7 @@ class UniverseTest extends WordSpec with Matchers {
         createNew()
         val e1 = Constant(8)
         e1.deactivate()
-        evaluating { universe.contextContents(e1) } should produce[NoSuchElementException]
+        an [NoSuchElementException] should be thrownBy  { universe.contextContents(e1) } 
       }
     }
   }

--- a/Figaro/src/test/scala/com/cra/figaro/test/library/compound/CompoundTest.scala
+++ b/Figaro/src/test/scala/com/cra/figaro/test/library/compound/CompoundTest.scala
@@ -246,11 +246,11 @@ class CompoundTest extends WordSpec with Matchers {
     "throw MatchError if no clause exists for a given parent value" in {
       Universe.createNew()
       val x = Flip(0.2)
-      evaluating {
+      an [MatchError] should be thrownBy {
         val y = CPD(x, true -> Flip(0.7))
         val alg = VariableElimination(y)
         alg.start()
-      } should produce[MatchError]
+      } 
     }
   }
 
@@ -275,7 +275,7 @@ class CompoundTest extends WordSpec with Matchers {
       Universe.createNew()
       val x1 = Flip(0.2)
       val x2 = Select(0.2 -> 1, 0.3 -> 2, 0.5 -> 3)
-      evaluating {
+      an [MatchError] should be thrownBy {
         val y = CPD(x1, x2, (false, 1) -> Flip(0.1),
           (false, 3) -> Flip(0.3),
           (true, 1) -> Flip(0.4),
@@ -283,7 +283,7 @@ class CompoundTest extends WordSpec with Matchers {
           (true, 3) -> Flip(0.6))
         val alg = VariableElimination(y)
         alg.start()
-      } should produce[MatchError]
+      } 
     }
   }
 
@@ -310,7 +310,7 @@ class CompoundTest extends WordSpec with Matchers {
       val x1 = Flip(0.2)
       val x2 = Select(0.2 -> 1, 0.3 -> 2, 0.5 -> 3)
       val x3 = Constant(7)
-      evaluating {
+      an [MatchError] should be thrownBy {
         val y = CPD(x1, x2, x3, (false, 1, 7) -> Flip(0.1),
           (false, 3, 7) -> Flip(0.3),
           (true, 1, 7) -> Flip(0.4),
@@ -318,7 +318,7 @@ class CompoundTest extends WordSpec with Matchers {
           (true, 3, 7) -> Flip(0.6))
         val alg = VariableElimination(y)
         alg.start()
-      } should produce[MatchError]
+      } 
     }
   }
 
@@ -356,7 +356,7 @@ class CompoundTest extends WordSpec with Matchers {
       val x2 = Select(0.2 -> 1, 0.3 -> 2, 0.5 -> 3)
       val x3 = Constant(7)
       val x4 = Flip(0.9)
-      evaluating {
+      an [MatchError] should be thrownBy {
         val y = CPD(x1, x2, x3, x4, (false, 1, 7, false) -> Flip(0.1),
           (false, 3, 7, false) -> Flip(0.3),
           (true, 1, 7, false) -> Flip(0.4),
@@ -370,7 +370,7 @@ class CompoundTest extends WordSpec with Matchers {
           (true, 3, 7, true) -> Flip(0.65))
         val alg = VariableElimination(y)
         alg.start()
-      } should produce[MatchError]
+      } 
     }
   }
 
@@ -410,7 +410,7 @@ class CompoundTest extends WordSpec with Matchers {
       val x3 = Constant(7)
       val x4 = Flip(0.9)
       val x5 = Constant('a)
-      evaluating {
+      an [MatchError] should be thrownBy {
         val y = CPD(x1, x2, x3, x4, x5, (false, 1, 7, false, 'a) -> Flip(0.1),
           (false, 3, 7, false, 'a) -> Flip(0.3),
           (true, 1, 7, false, 'a) -> Flip(0.4),
@@ -424,7 +424,7 @@ class CompoundTest extends WordSpec with Matchers {
           (true, 3, 7, true, 'a) -> Flip(0.65))
         val alg = VariableElimination(y)
         alg.start()
-      } should produce[MatchError]
+      } 
     }
   }
 

--- a/Figaro/src/test/scala/com/cra/figaro/test/util/PriorityMapTest.scala
+++ b/Figaro/src/test/scala/com/cra/figaro/test/util/PriorityMapTest.scala
@@ -82,7 +82,7 @@ class PriorityMapTest extends WordSpec with Matchers {
       hpm.extractMin() should equal(("bar", 1))
       hpm.extractMin() should equal(("foo", 2))
       hpm.extractMin() should equal(("baz", 3))
-      evaluating { hpm.extractMin() } should produce[IllegalArgumentException]
+      an [IllegalArgumentException] should be thrownBy { hpm.extractMin() } 
     }
 
     "iterate over the elements from lowest to highest" in {
@@ -113,7 +113,7 @@ class PriorityMapTest extends WordSpec with Matchers {
       hpm2.extractMin() should equal(("bar", 1))
       hpm2.extractMin() should equal(("foo", 2))
       hpm2.extractMin() should equal(("baz", 3))
-      evaluating { hpm2.extractMin() } should produce[IllegalArgumentException]
+      an [IllegalArgumentException] should be thrownBy { hpm2.extractMin() } 
     }
 
     "take roughly log n time for inserting" taggedAs (PerformanceTest) in {

--- a/Figaro/src/test/scala/com/cra/figaro/test/util/UtilTest.scala
+++ b/Figaro/src/test/scala/com/cra/figaro/test/util/UtilTest.scala
@@ -54,7 +54,7 @@ class UtilTest extends WordSpec with Matchers {
 
     "given a list with zero total value" should {
       "throw a ZeroTotalUnnormalizedProbabilityException" in {
-        evaluating { normalize(List(0.0, 0.0)) } should produce[ZeroTotalUnnormalizedProbabilityException]
+        an [ZeroTotalUnnormalizedProbabilityException] should be thrownBy { normalize(List(0.0, 0.0)) } 
       }
     }
   }
@@ -70,7 +70,7 @@ class UtilTest extends WordSpec with Matchers {
     "given an index that is greater than the sum of the probabilities" should {
       "throw InvalidMultinomialIndexException" in {
         val m = List(0.2 -> 'foo, 0.3 -> 'bar, 0.5 -> 'baz)
-        evaluating { selectMultinomial(1.2, m) } should produce[InvalidMultinomialIndexException]
+        an [InvalidMultinomialIndexException] should be thrownBy { selectMultinomial(1.2, m) } 
       }
     }
   }
@@ -152,7 +152,7 @@ class UtilTest extends WordSpec with Matchers {
 
     "given a traversable, a value, and a set of indices such that some indices are too large" should {
       "throw IllegalArgumentException" in {
-        evaluating { insertAtIndices(List(1, 2), List(0, 2, 5), 3) } should produce[IllegalArgumentException]
+        an [IllegalArgumentException] should be thrownBy { insertAtIndices(List(1, 2), List(0, 2, 5), 3) } 
       }
     }
   }


### PR DESCRIPTION
Warnings in test relate to deprecated syntax. These have been fixed and tests successfully run under both Scala 10 and Scala 11 (note Scala 11 requires Scalatest 11).
