### PR TITLE
Do not copy but just update the state's oldValues when adding a new element

### DIFF
--- a/Figaro/src/main/scala/com/cra/figaro/algorithm/sampling/MetropolisHastings.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/algorithm/sampling/MetropolisHastings.scala
@@ -70,7 +70,7 @@ abstract class MetropolisHastings(universe: Universe, proposalScheme: ProposalSc
     val newValue = elem.generateValue(elem.randomness)
     // if an old value is already stored, don't overwrite it
     val newOldValues =
-      if (state.oldValues contains elem) state.oldValues; else state.oldValues + (elem -> elem.value)
+      if (state.oldValues contains elem) state.oldValues; else state.oldValues += (elem -> elem.value)
     if (elem.value != newValue) {
       //val newProb =
       //  state.modelProb * elem.score(elem.value, newValue)


### PR DESCRIPTION
Is there any reason why we would create a copy (`+`) of `oldValues` rather than just updating (`+=`) the mutable Map with the new Element?

I'm getting huge speed improvements with this change (when layers of independent elements are generated just once at the beginning of the sampling process; see https://github.com/Synapski/figaro/compare/dev) for a large network.
