### PR TITLE
Use a filter, instead of a set subtraction, to avoid iterating through state.assigned every time

### DIFF
--- a/Figaro/src/main/scala/com/cra/figaro/algorithm/sampling/Importance.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/algorithm/sampling/Importance.scala
@@ -251,8 +251,9 @@ abstract class Importance(universe: Universe, targets: Element[_]*)
   @tailrec
   private def sampleArgs(element: Element[_], state: State, args: Set[Element[_]]): Unit = {
     args foreach (sampleOne(state, _, None))
-    val newArgs = Set[Element[_]](element.args:_*) -- state.assigned
-    if (newArgs.nonEmpty) sampleArgs(element, state, newArgs) else return
+    val newArgs = element.args.filter(!state.assigned.contains(_))
+    if (newArgs.nonEmpty)
+      sampleArgs(element, state, Set[Element[_]](newArgs: _*))
   }
 
    /**


### PR DESCRIPTION
This cuts down the Importance sampling benchmarks quite a bit by avoiding the iteration through `state.assigned` every time. Besides some rare edge cases `state.assigned` will generally be larger, and usually much larger, than `element.args` because even in the simplest case, everything in the latter will have been already added to the former by this point, along with any other element that has been sampled.