### PR TITLE
Two other instances where a set subtraction operation would be faster as a filter

### DIFF
--- a/Figaro/src/main/scala/com/cra/figaro/algorithm/factored/FactoredAlgorithm.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/algorithm/factored/FactoredAlgorithm.scala
@@ -73,7 +73,8 @@ trait FactoredAlgorithm[T] extends Algorithm {
         if (depth >= 0) {
           val includeThisElement = depth > LazyValues(element.universe).expandedDepth(element).getOrElse(-1)
           // Keeping track of what's been chased so far avoids infinite recursion
-          val toChase = element.universe.directlyUsedBy(element).toSet ++ dependentUniverseCoparents.getOrElse(element, Set()) -- chasedSoFar
+          val related = element.universe.directlyUsedBy(element).toSet ++ dependentUniverseCoparents.getOrElse(element, Set())
+          val toChase = related.filter(!chasedSoFar.contains(_))
           val rest = toChase.flatMap((elem: Element[_]) => chaseDown(elem, depth - 1, chasedSoFar ++ toChase))
           if (includeThisElement) rest + ((element, depth)); else rest
         } else Set()

--- a/Figaro/src/main/scala/com/cra/figaro/algorithm/sampling/Forward.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/algorithm/sampling/Forward.scala
@@ -80,7 +80,7 @@ object Forward {
             var argsRemaining = initialArgs 
             while (!argsRemaining.isEmpty) {
               state1 = sampleInState(argsRemaining.head, state1, universe, useObservation)
-              val newArgs = element.args.toSet -- initialArgs
+              val newArgs = element.args.filter(!initialArgs.contains(_))
               initialArgs = initialArgs ++ newArgs
               argsRemaining = argsRemaining.tail ++ newArgs
             }


### PR DESCRIPTION
Of all the other uses of the set subtraction operator, these are two where the set being subtracted is generally larger. Both of these improve benchmark run times, especially the FactoredAlgorithm case.