### PR TITLE
Several changes:

### DIFF
--- a/Figaro/src/main/scala/com/cra/figaro/algorithm/Anytime.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/algorithm/Anytime.scala
@@ -16,6 +16,13 @@ package com.cra.figaro.algorithm
 import com.cra.figaro.language._
 import akka.actor._
 import com.typesafe.config.ConfigFactory
+import akka.util.Timeout
+import java.util.concurrent.TimeUnit
+import akka.pattern.{ ask }
+import scala.concurrent.Await
+import scala.concurrent.Future
+import java.util.concurrent.TimeoutException
+import scala.concurrent.duration.Duration
 
 /**
  * Class of services implemented by the anytime algorithm.
@@ -26,8 +33,14 @@ abstract class Service
  * Class of responses to services.
  */
 abstract class Response
+
 /**
- * General Response (String)
+ * Ack Response (String)
+ */
+case object AckResponse extends Response
+
+/**
+ * Exception Response (String)
  */
 case class ExceptionResponse(msg: String) extends Response
 
@@ -40,6 +53,9 @@ sealed abstract class Message
  */
 case class Handle(service: Service) extends Message
 
+
+class AnytimeAlgorithmException(s: String) extends RuntimeException(s)
+
 /**
  * An anytime algorithm is able to improve its estimated answers over time. Anytime algorithms run in their
  * own thread using an actor.
@@ -50,15 +66,6 @@ case class Handle(service: Service) extends Message
  */
 
 trait Anytime extends Algorithm {
-  /**
-   * Run a single step of the algorithm. The algorithm must be able to provide answers after each step.
-   */
-  def runStep(): Unit
-
-  /**
-   * Optional function to run when the algorithm is stopped (not killed). Used in samplers to update lazy values.
-   */
-  def stopUpdate(): Unit = {  }
 
   /**
    * A class representing the actor running the algorithm.
@@ -71,7 +78,8 @@ trait Anytime extends Algorithm {
         sender ! handle(service)
       case "stop" =>
         stopUpdate()
-        become (inactive)
+        sender ! AckResponse
+        become(inactive)
       case "next" =>
         runStep()
         self ! "next"
@@ -89,9 +97,11 @@ trait Anytime extends Algorithm {
       case "resume" =>
         resume()
         become(active)
-      	self ! "next"
+        self ! "next"
       case "kill" =>
-         become(shuttingDown)
+        cleanUp()
+        sender ! AckResponse
+        become(shuttingDown)
       case _ =>
         sender ! ExceptionResponse("Algorithm is stopped")
     }
@@ -102,8 +112,6 @@ trait Anytime extends Algorithm {
     }
 
     def receive = inactive
-
-
   }
 
   /**
@@ -121,6 +129,18 @@ trait Anytime extends Algorithm {
   var runner: ActorRef = null
   var running = false;
 
+  implicit var messageTimeout = Timeout(5000, TimeUnit.MILLISECONDS)
+
+  /**
+   * Run a single step of the algorithm. The algorithm must be able to provide answers after each step.
+   */
+  def runStep(): Unit
+
+  /**
+   * Optional function to run when the algorithm is stopped (not killed). Used in samplers to update lazy values.
+   */
+  def stopUpdate(): Unit = {}
+
   /**
    * A handler of services provided by the algorithm.
    */
@@ -129,10 +149,10 @@ trait Anytime extends Algorithm {
 
   protected[algorithm] def doStart() = {
     if (!running) {
-    	system = ActorSystem("Anytime", ConfigFactory.load(customConf))
-    	runner = system.actorOf(Props(new Runner))
-    	initialize()
-    	running = true
+      system = ActorSystem("Anytime", ConfigFactory.load(customConf))
+      runner = system.actorOf(Props(new Runner))
+      initialize()
+      running = true
     }
 
     runner ! "start"
@@ -150,12 +170,31 @@ trait Anytime extends Algorithm {
    * Release all resources from this anytime algorithm.
    */
   def shutdown {
-    cleanUp()
-    if (running)
-    {
-    	runner ! "kill"
-    	system.stop(runner)
-    	system.shutdown
+    if (running) {      
+      awaitResponse(runner ? "kill", messageTimeout.duration)      
+      system.stop(runner)
+      system.shutdown
     }
   }
+  
+  def awaitResponse(response: Future[Any], duration: Duration): Response = {
+    try {
+      val result = Await.result(response, duration) 
+      result match {
+        case e: ExceptionResponse => {
+          println(e.msg)
+          e
+        }
+        case r: Response => r
+        case _ => throw new AnytimeAlgorithmException("Unknown Response")
+      }
+    } catch {
+      case to: TimeoutException => {
+        println("Error! Did not receive a response from algorithm thread - it may be hanging or taking an exceptionally long time to respond. Try increasing messageTimeout.")
+        ExceptionResponse("Timeout")
+      }
+      case e: Exception => throw e
+    } 
+  }
+  
 }

--- a/Figaro/src/main/scala/com/cra/figaro/algorithm/Anytime.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/algorithm/Anytime.scala
@@ -129,6 +129,9 @@ trait Anytime extends Algorithm {
   var runner: ActorRef = null
   var running = false;
 
+  /**
+   * default message timeout. Increase if queries to the algorithm fail due to timeout
+   */
   implicit var messageTimeout = Timeout(5000, TimeUnit.MILLISECONDS)
 
   /**
@@ -177,7 +180,12 @@ trait Anytime extends Algorithm {
     }
   }
   
-  def awaitResponse(response: Future[Any], duration: Duration): Response = {
+  /*
+   * A helper function to query the running thread and await a response.
+   * In the case that it times out, it will print a message that it timed out and return an exception response.
+   * Note, on a time, it does NOT throw an exception.
+   */
+  protected def awaitResponse(response: Future[Any], duration: Duration): Response = {
     try {
       val result = Await.result(response, duration) 
       result match {

--- a/Figaro/src/main/scala/com/cra/figaro/algorithm/AnytimeMPE.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/algorithm/AnytimeMPE.scala
@@ -14,6 +14,7 @@
 package com.cra.figaro.algorithm
 
 import com.cra.figaro.language._
+import akka.pattern.{ask}
 
 /**
  * Anytime algorithms that compute most likely values of elements.
@@ -25,7 +26,7 @@ trait AnytimeMPE extends MPEAlgorithm with Anytime {
    * A message instructing the handler to compute the most likely value of the target element.
    */
   case class ComputeMostLikelyValue[T](target: Element[T]) extends Service
-  
+
   /**
    * A message from the handler containing the most likely value of the previously requested element.
    */
@@ -36,4 +37,14 @@ trait AnytimeMPE extends MPEAlgorithm with Anytime {
       case ComputeMostLikelyValue(target) =>
         MostLikelyValue(mostLikelyValue(target))
     }
+  
+  protected def doMostLikelyValue[T](target: Element[T]): T = {
+    awaitResponse(runner ? Handle(ComputeMostLikelyValue(target)), messageTimeout.duration) match {
+      case MostLikelyValue(result) => result.asInstanceOf[T]
+      case _ => {
+        println("Error: Response not recognized from algorithm")
+        target.value 
+      }
+    }
+  }
 }

--- a/Figaro/src/main/scala/com/cra/figaro/algorithm/AnytimeProbEvidence.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/algorithm/AnytimeProbEvidence.scala
@@ -37,18 +37,12 @@ trait AnytimeProbEvidence extends ProbEvidenceAlgorithm with Anytime {
   /**
    * Returns the probability of evidence of the universe on which the algorithm operates.
    * Throws AlgorithmInactiveException if the algorithm is not active.
-   */
-  implicit val timeout = Timeout(5000, TimeUnit.MILLISECONDS)
+   */  
   def probabilityOfEvidence(): Double = {
-    if (!active) throw new AlgorithmInactiveException
-    val response = runner ? Handle(ComputeProbEvidence)
-    Await.result(response, timeout.duration ).asInstanceOf[Response] match {
+    awaitResponse(runner ? Handle(ComputeProbEvidence), messageTimeout.duration) match {
       case ProbEvidence(result) => result
-      case ExceptionResponse(msg) =>
-        println(msg)
-        0.0
       case _ => 0.0
-    }
+    }    
   }
 
 }

--- a/Figaro/src/main/scala/com/cra/figaro/algorithm/MPEAlgorithm.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/algorithm/MPEAlgorithm.scala
@@ -28,4 +28,7 @@ trait MPEAlgorithm extends Algorithm {
    * Returns the most likely value for the target element.
    */
   def mostLikelyValue[T](target: Element[T]): T
+  
+  // Defined in one time or anytime versions
+  protected def doMostLikelyValue[T](target: Element[T]): T
 }

--- a/Figaro/src/main/scala/com/cra/figaro/algorithm/OneTimeMPE.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/algorithm/OneTimeMPE.scala
@@ -19,4 +19,6 @@ import com.cra.figaro.language._
  * One-time algorithms that compute the most likely values of elements.
  * A class that implements this trait must implement run and mostLikelyValue methods.
  */
-trait OneTimeMPE extends MPEAlgorithm with OneTime
+trait OneTimeMPE extends MPEAlgorithm with OneTime {
+  protected def doMostLikelyValue[T](target: Element[T]): T = mostLikelyValue(target)
+}

--- a/Figaro/src/main/scala/com/cra/figaro/algorithm/sampling/ElementSampler.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/algorithm/sampling/ElementSampler.scala
@@ -25,7 +25,7 @@ import scala.collection.mutable.Map
 abstract class ElementSampler(target: Element[_]) extends BaseUnweightedSampler(target.universe, target) {
 
   def sample(): (Boolean, Sample) = {
-    Forward(target)
+    Forward(target)    
     (true, Map[Element[_], Any](target -> target.value))
   }
 

--- a/Figaro/src/main/scala/com/cra/figaro/algorithm/sampling/UnweightedSampler.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/algorithm/sampling/UnweightedSampler.scala
@@ -86,7 +86,7 @@ abstract class BaseUnweightedSampler(val universe: Universe, targets: Element[_]
 
   protected def update(): Unit = {
     sampleCount += 1
-    targets.foreach(t => updateTimesSeenForTarget(t.asInstanceOf[Element[t.Value]], t.value))
+    if (allLastUpdates.nonEmpty) targets.foreach(t => updateTimesSeenForTarget(t.asInstanceOf[Element[t.Value]], t.value))    
     sampleCount -= 1
   }
 
@@ -100,8 +100,13 @@ trait UnweightedSampler extends BaseUnweightedSampler with ProbQuerySampler {
   def getTotalWeight: Double = math.log(getSampleCount)
 
   override protected[algorithm] def computeProjection[T](target: Element[T]): List[(T, Double)] = {
+    if (allLastUpdates.nonEmpty) {
     val timesSeen = allTimesSeen.find(_._1 == target).get._2.asInstanceOf[Map[T, Int]]
     timesSeen.mapValues(_ / sampleCount.toDouble).toList
+    } else {
+      println("Error: MH sampler did not accept any samples")
+      List()
+    }
   }
 
 }

--- a/Figaro/src/test/scala/com/cra/figaro/test/algorithm/sampling/ElementSamplerTest.scala
+++ b/Figaro/src/test/scala/com/cra/figaro/test/algorithm/sampling/ElementSamplerTest.scala
@@ -259,6 +259,7 @@ class ElementSamplerTest extends WordSpec with Matchers with PrivateMethodTester
     val es = ElementSampler(target)
     es.start
     Thread.sleep(1000)
+    es.stop
     val predProb = es.probability(target, predicate)
     predProb should be(prob +- epsilon)
     es.kill

--- a/Figaro/src/test/scala/com/cra/figaro/test/experimental/particlebp/PBPTest.scala
+++ b/Figaro/src/test/scala/com/cra/figaro/test/experimental/particlebp/PBPTest.scala
@@ -37,6 +37,8 @@ import com.cra.figaro.experimental.particlebp.AutomaticDensityEstimator
 import com.cra.figaro.algorithm.sampling.ProbEvidenceSampler
 import com.cra.figaro.ndtest._
 import org.apache.commons.math3.distribution.MultivariateNormalDistribution
+import akka.util.Timeout
+import java.util.concurrent.TimeUnit
 
 class PBPTest extends WordSpec with Matchers {
 
@@ -209,7 +211,7 @@ class PBPTest extends WordSpec with Matchers {
           // U(false) = \int_{0.2}^{1.0) (1-p)
           val u1 = 0.35 * 0.96
           val u2 = 0.32
-          val result = test(f, 5000, 250, 100, 100, (b: Boolean) => b, u1 / (u1 + u2), globalTol, false)
+          val result = test(f, 5000, 500, 100, 100, (b: Boolean) => b, u1 / (u1 + u2), globalTol, false)
           update(result, NDTest.TTEST, "ConditionOnDependentElement", u1 / (u1 + u2), alpha)
         }
       }
@@ -228,7 +230,7 @@ class PBPTest extends WordSpec with Matchers {
           // U(false) = \int_{0.2}^(1.0) (2 * (1-p)) = 0.64
           val u1 = 0.85 * 0.96
           val u2 = 0.64
-          val result = test(f, 5000, 250, 100, 100, (b: Boolean) => b, u1 / (u1 + u2), globalTol, false)
+          val result = test(f, 5000, 500, 100, 100, (b: Boolean) => b, u1 / (u1 + u2), globalTol, false)
           update(result, NDTest.TTEST, "ConstraintOnDependentElement", u1 / (u1 + u2), alpha)
         }
       }
@@ -412,7 +414,9 @@ class PBPTest extends WordSpec with Matchers {
     val algorithm = if (oneTime) {
       ParticleBeliefPropagation(outer, inner, argSamples, totalSamples, target)
     } else {
-      ParticleBeliefPropagation(inner.toLong, argSamples, totalSamples, target)
+      val alg = ParticleBeliefPropagation(inner.toLong, argSamples, totalSamples, target)
+      alg.messageTimeout = Timeout(30000, TimeUnit.MILLISECONDS)
+      alg
     }
     algorithm.start()
     if (!oneTime) Thread.sleep(outer.toLong)


### PR DESCRIPTION
1. Fixes for issue #455. Anytime algorithms now block on calls to stop,
kill and query. This ensures that the anytime algorithm has completed
its last operation before any new operation has performed. Will now
throw an error if the operation times out.

2. Fixed key not found errors in Unweighted sampler. If one never gets a
valid sampling in MH, then the data structures will not be initialized.
Checks for empty data structures and returns an empty list if so. This
should fix issue #473.

3. Various small fixes.