### PR TITLE
Several changes:

### DIFF
--- a/Figaro/src/main/scala/com/cra/figaro/algorithm/factored/factors/Factory.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/algorithm/factored/factors/Factory.scala
@@ -323,7 +323,7 @@ object Factory {
       case r: SingleValuedReferenceElement[_] => ComplexFactory.makeFactors(r)
       case r: MultiValuedReferenceElement[_] => ComplexFactory.makeFactors(r)
       case r: Aggregate[_, _] => ComplexFactory.makeFactors(r)
-      case m: MakeList[_] => ComplexFactory.makeFactors(m)
+      //case m: MakeList[_] => ComplexFactory.makeFactors(m)
       case m: MakeArray[_] => ComplexFactory.makeFactors(m)
       case f: FoldLeft[_, _] => ComplexFactory.makeFactors(f)
       case f: FactorMaker[_] => f.makeFactors

--- a/Figaro/src/main/scala/com/cra/figaro/algorithm/factored/factors/factory/ComplexFactory.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/algorithm/factored/factors/factory/ComplexFactory.scala
@@ -125,27 +125,6 @@ object ComplexFactory {
     List(factor)
   }
 
-  /**
-   * Constructor for a MakeList Element
-   */
-  def makeFactors[T](element: MakeList[T]): List[Factor[Double]] = {
-    val parentVar = Variable(element.numItems)
-    // We need to create factors for the items and the lists themselves, which are encapsulated in this MakeList
-    val regularParents = parentVar.range.filter(_.isRegular).map(_.value)
-    val maxItem = regularParents.reduce(_ max _)
-    val itemFactors = List.tabulate(maxItem)((i: Int) => Factory.make(element.items(i)))
-    val indexedResultElemsAndFactors =
-      for { i <- regularParents } yield {
-        val elem = element.embeddedInject(i)
-        val factors = Factory.make(elem)
-        (Regular(i), elem, factors)
-      }
-    val conditionalFactors =
-      parentVar.range.zipWithIndex map (pair =>
-        Factory.makeConditionalSelector(element, parentVar, pair._2, Variable(indexedResultElemsAndFactors.find(_._1 == pair._1).get._2)))
-    conditionalFactors ::: itemFactors.flatten ::: indexedResultElemsAndFactors.flatMap(_._3)
-  }
-
   // adapted from Apply1
   /**
    * Factor constructor for a MakeArray Element

--- a/Figaro/src/main/scala/com/cra/figaro/algorithm/learning/GeneralizedEM.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/algorithm/learning/GeneralizedEM.scala
@@ -194,18 +194,18 @@ class GeneralizedOnlineEM(inferenceAlgorithmConstructor: Seq[Element[_]] => Univ
     //println("universe: " + currentUniverse.hashCode)
     var result: Map[Parameter[_], Seq[Double]] = Map()
 
-    val uses = usesParameter(inferenceTargets)
-    println("built map")
+    val uses = usesParameter(inferenceTargets)    
     for { parameter <- targetParameters } {
       var stats = parameter.zeroSufficientStatistics
-      for {
-        target <- uses(parameter)
-      } {
-        println("found used by...")
-        val t: Parameterized[target.Value] = target.asInstanceOf[Parameterized[target.Value]]
-        val distribution: Stream[(Double, target.Value)] = algorithm.distribution(t)
-        val newStats = t.distributionToStatistics(parameter, distribution)
-        stats = (stats.zip(newStats)).map(pair => pair._1 + pair._2)
+      if (uses.contains(parameter)) {
+        for {
+          target <- uses(parameter)
+        } {
+          val t: Parameterized[target.Value] = target.asInstanceOf[Parameterized[target.Value]]
+          val distribution: Stream[(Double, target.Value)] = algorithm.distribution(t)
+          val newStats = t.distributionToStatistics(parameter, distribution)
+          stats = (stats.zip(newStats)).map(pair => pair._1 + pair._2)
+        }
       }
       result += parameter -> stats
     }

--- a/Figaro/src/main/scala/com/cra/figaro/language/Evidence.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/language/Evidence.scala
@@ -60,7 +60,10 @@ case class LogConstraint[T](function: T => Double) extends Evidence[T] {
 }
 
 /**
- * Evidence representing observing a particular value for the element.
+ * Evidence representing observing a particular value for the element. Note that using an Observation
+ * on a reference is not the same as calling observe on the element directly. This version applies
+ * a condition to the element, thus bypassing some specialized operations that can be accomplished
+ * by calling the observe on the element directly (such as Likelihood weighting). 
  * 
  * @param value The observed value of the element.
  */

--- a/Figaro/src/main/scala/com/cra/figaro/library/collection/VariableSizeArray.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/library/collection/VariableSizeArray.scala
@@ -21,7 +21,7 @@ import com.cra.figaro.algorithm.factored._
 /**
  * Holder for an element whose value is a fixed size array.
  */
-class FixedSizeArrayElement[Value](private val fsa: Element[FixedSizeArray[Value]])
+class FixedSizeArrayElement[Value](protected[figaro] val fsa: Element[FixedSizeArray[Value]])
 extends ContainerElement[Int, Value](fsa.asInstanceOf[Element[Container[Int, Value]]]) {
 
   /**

--- a/Figaro/src/main/scala/com/cra/figaro/library/compound/MakeList.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/library/compound/MakeList.scala
@@ -14,11 +14,15 @@
 package com.cra.figaro.library.compound
 
 import com.cra.figaro.algorithm.ValuesMaker
-import com.cra.figaro.algorithm.lazyfactored.{ValueSet, LazyValues, Regular}
+import com.cra.figaro.algorithm.lazyfactored.{ ValueSet, LazyValues, Regular }
 import com.cra.figaro.algorithm.factored.factors._
 import com.cra.figaro.language._
 import com.cra.figaro.util._
 import scala.collection.mutable.Map
+import com.cra.figaro.library.collection.VariableSizeArray
+import com.cra.figaro.library.collection.FixedSizeArrayElement
+import com.cra.figaro.library.collection.FixedSizeArray
+import com.cra.figaro.library.collection.MakeArray
 
 /**
  * An element representing making a list of a random number of random items.
@@ -28,98 +32,20 @@ import scala.collection.mutable.Map
  *
  * @param numItems The element representing the number of items in the list
  * @param itemMaker A function that creates an element representing a single item in the list
+ * @deprecated("MakeList is deprecated. Please use the collections library for future support of MakeList capabilities", "3.2.1")
  */
-class MakeList[T](
-  name: Name[List[T]],
-  val numItems: Element[Int],
-  val itemMaker: () => Element[T],
-  collection: ElementCollection)
-  extends Deterministic[List[T]](name, collection)
-  with ValuesMaker[List[T]] with IfArgsCacheable[List[T]] {
 
-  /**
-   * An infinite stream of items in the list. At any point in time, the value of this element
-   * is the prefix of items specified by the value of numItems.
-   */
-  lazy val items = Stream.continually({
-    val item = itemMaker()
-    universe.registerUses(this, item)
-    item
-  })
-
-  override def args = numItems :: (items take numItems.value).toList
-
-  override def generateValue = (items take numItems.value map (_.value)).toList
-
-  /**
-   * Return the i-th item in the list. Throws IllegalArgumentException if i is greater
-   * than the current value of numItems
-   */
-  def apply(i: Int) = i < numItems.value match {
-    case true => items(i)
+@deprecated("MakeList is deprecated. Please use the collections library for future support of MakeList capabilities", "3.2.1")
+class MakeList[T](name: Name[List[T]], vsa: FixedSizeArrayElement[T], collection: ElementCollection)
+  extends Apply1[List[T], List[T]](name, vsa.foldLeft(List[T]())((c: List[T], n: T) => c :+ n), (l: List[T]) => l, collection) {
+  
+  val numItems = vsa.fsa.asInstanceOf[MakeArray[T]].numItems
+  
+  def items = vsa.fsa.value.generate(vsa.fsa.value.indices.toList).map(_._2).toStream
+  
+  def apply(i: Int) = i < vsa.fsa.value.size match {
+    case true => vsa.fsa.value(i)
     case _ => throw new IllegalArgumentException("Invalid indices to MakeList")
-  }
-
-  private def values = LazyValues(universe)
-
-  /* We need to make sure that values are computed on the embedded Injects. Therefore, we create them in makeValues, store them, and use them in makeFactors.
-   */
-  val embeddedInject: Map[Int, Element[List[T]]] = Map()
-
-  def makeValues(depth: Int): ValueSet[List[T]] = {
-    // This code is subtle.
-    // If we used itemMaker here, it would create bugs, as the items that appeared in the values would be different from the ones actually used by the Makelist.
-    // On the other hand, if we used Values(items(0)) as a template for the values of all items, it would create other bugs, as different indices would have the same values,
-    // even when the values include "new C", so they should all be different.
-    // Therefore, we use Values()(items(i)) to get the possible value for each item in the stream.
-    def possibleItemLists(length: Int): ValueSet[List[T]] = {
-      val inject = Inject(items.take(length):_*)
-      embeddedInject += length -> inject
-     values(inject, depth - 1)
-    }
-    val possibleLengthValues = values(numItems, depth - 1)
-    val possibleLengths = possibleLengthValues.regularValues
-    val itemListsForLengths = possibleLengths.map(possibleItemLists(_))
-    val resultValues =
-      for {
-        itemLists <- itemListsForLengths
-        list <- itemLists.regularValues
-      } yield list
-    val incomplete = itemListsForLengths.exists(_.hasStar) || possibleLengthValues.hasStar
-    if (incomplete) ValueSet.withStar(resultValues); else ValueSet.withoutStar(resultValues)
-  }
-
-//  def makeFactors: List[Factor[Double]] = {
-//    val parentVar = Variable(numItems)
-//    // We need to create factors for the items and the lists themselves, which are encapsulated in this MakeList
-//    val regularParents = parentVar.range.filter(_.isRegular).map(_.value)
-//    val maxItem = regularParents.reduce(_ max _)
-//    val itemFactors = List.tabulate(maxItem)((i: Int) => Factory.make(items(i)))
-//    val indexedResultElemsAndFactors =
-//      for { i <- regularParents } yield {
-//        val elem = embeddedInject(i)
-//        val factors = Factory.make(elem)
-//        (Regular(i), elem, factors)
-//      }
-//    val conditionalFactors =
-//      parentVar.range.zipWithIndex map (pair =>
-//        Factory.makeConditionalSelector(this, parentVar, pair._2, Variable(indexedResultElemsAndFactors.find(_._1 == pair._1).get._2)))
-//    conditionalFactors ::: itemFactors.flatten ::: indexedResultElemsAndFactors.flatMap(_._3)
-//  }
-
-  override def isCachable = {
-
-    if (itemMaker().isCachable == false) {
-      false
-    }
-
-    for (arg <- args) yield {
-      if (arg.isCachable == false) {
-        false
-      }
-    }
-
-    true
   }
 
 }
@@ -129,7 +55,12 @@ object MakeList {
    * Create a MakeList element using numItems to determine the number of items
    * and itemMaker to create each item in the list.
    */
+  @deprecated("MakeList is deprecated. Please use the collections library for future support of MakeList capabilities", "3.2.1")
   def apply[T](numItems: Element[Int], itemMaker: () => Element[T])(implicit name: Name[List[T]], collection: ElementCollection) = {
-    new MakeList(name, numItems, itemMaker, collection)
+    val vsa = VariableSizeArray(numItems, (i: Int) => itemMaker())("", collection)   
+    new MakeList(name, vsa, collection)
   }
+  
 }
+
+

--- a/Figaro/src/test/scala/com/cra/figaro/test/library/atomic/continuous/ContinuousTest.scala
+++ b/Figaro/src/test/scala/com/cra/figaro/test/library/atomic/continuous/ContinuousTest.scala
@@ -316,11 +316,8 @@ class ContinuousTest extends WordSpec with Matchers {
         override def oneTest = {
           val sampleUniverse = Universe.createNew()
           val nSamples = Normal(2.5, 2.0)("", sampleUniverse)
-          val samples = for (i <- 1 to 25)
+          val samples = for (i <- 1 to 200)
             yield nSamples.generateValue(nSamples.generateRandomness())
-
-//          val samplesMean = samples.sum / samples.size
-//          val samplesVariance = samples.map(s => (s - samplesMean) * (s - samplesMean)).sum / (samples.size - 1)
 
           val universe = Universe.createNew()
           val mean = Uniform(-5, 5)("mean", universe)
@@ -330,7 +327,7 @@ class ContinuousTest extends WordSpec with Matchers {
             normal.observe(sample)
           }
 
-          val alg = Importance(20000, mean, variance)
+          val alg = Importance(2000, mean, variance)
           alg.start()
           val result1 = alg.mean(mean)
           val result2 = alg.mean(variance)
@@ -634,7 +631,7 @@ class ContinuousTest extends WordSpec with Matchers {
         override def oneTest = {
           val sampleUniverse = Universe.createNew()
           val nSamples = Exponential(2)("", sampleUniverse)
-          val samples = for (i <- 1 to 25)
+          val samples = for (i <- 1 to 200)
             yield nSamples.generateValue(nSamples.generateRandomness())
 
           val universe = Universe.createNew()
@@ -643,7 +640,7 @@ class ContinuousTest extends WordSpec with Matchers {
             val exponential = Exponential(lambda)
             exponential.observe(sample)
           }
-          val alg = Importance(20000, lambda)
+          val alg = Importance(2000, lambda)
           alg.start()
           val target = 2.0
           val result = alg.mean(lambda)
@@ -955,7 +952,7 @@ class ContinuousTest extends WordSpec with Matchers {
           val sampleUniverse = Universe.createNew()
           val nSamples = Gamma(2, 2)("", sampleUniverse)
 
-          val samples = for (i <- 1 to 25)
+          val samples = for (i <- 1 to 200)
             yield nSamples.generateValue(nSamples.generateRandomness())
 
           val universe = Universe.createNew()
@@ -966,7 +963,7 @@ class ContinuousTest extends WordSpec with Matchers {
             gamma.observe(sample)
           }
 
-          val alg = Importance(20000, k, theta)
+          val alg = Importance(2000, k, theta)
           alg.start()
           val resultK = alg.mean(k)
           val resultTheta = alg.mean(theta)
@@ -1109,7 +1106,7 @@ class ContinuousTest extends WordSpec with Matchers {
         override def oneTest = {
           val sampleUniverse = Universe.createNew()
           val nSamples = Beta(2, 5)("", sampleUniverse)
-          val samples = for (i <- 1 to 25)
+          val samples = for (i <- 1 to 200)
             yield nSamples.generateValue(nSamples.generateRandomness())
 
           val universe = Universe.createNew()
@@ -1119,7 +1116,7 @@ class ContinuousTest extends WordSpec with Matchers {
             val beta = Beta(a, b)
             beta.observe(sample)
           }
-          val alg = Importance(40000, a, b)
+          val alg = Importance(2000, a, b)
           alg.start()
           val resultA = alg.mean(a)
           val resultB = alg.mean(b)
@@ -1293,7 +1290,7 @@ class ContinuousTest extends WordSpec with Matchers {
         override def oneTest = {
           val sampleUniverse = Universe.createNew()
           val nSamples = Dirichlet(1, 2, 3)("", sampleUniverse)
-          val samples = for (i <- 1 to 25)
+          val samples = for (i <- 1 to 200)
             yield nSamples.generateValue(nSamples.generateRandomness())
 
           val universe = Universe.createNew()
@@ -1304,7 +1301,7 @@ class ContinuousTest extends WordSpec with Matchers {
             val dirichlet = Dirichlet(alpha1, alpha2, alpha3)
             dirichlet.observe(sample)
           }
-          val alg = Importance(30000, alpha1, alpha2, alpha3)
+          val alg = Importance(2000, alpha1, alpha2, alpha3)
           alg.start()
           val resultA = alg.mean(alpha1)
           val resultB = alg.mean(alpha2)


### PR DESCRIPTION
1. MakeList has been converted to the collections library and
deprecated. We should now encourage people to use the collections over
MakeList.

2. Fix bug in generalized EM causing exception.

3. Added comment to Observation class to note that it is different than
a direct observation on the element.

4. Changed the compound tests in ContinuousTest to use less Importance
sampling iterations but takes more samples from the original
distribution, resulting in a more stable test.