### PR TITLE
Fixes for two small bugs. 

### DIFF
--- a/Figaro/src/main/scala/com/cra/figaro/algorithm/sampling/ElementSampler.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/algorithm/sampling/ElementSampler.scala
@@ -26,7 +26,6 @@ abstract class ElementSampler(target: Element[_]) extends BaseUnweightedSampler(
 
   def sample(): (Boolean, Sample) = {
     Forward(target)    
-    universe.clearTemporaries
     (true, Map[Element[_], Any](target -> target.value))
   }
 
@@ -78,6 +77,7 @@ class OneTimeElementSampler(target: Element[_], myNumSamples: Int)
     doInitialize()
     super.run()
     update
+    universe.clearTemporaries
   }
 }
 

--- a/Figaro/src/main/scala/com/cra/figaro/algorithm/sampling/Forward.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/algorithm/sampling/Forward.scala
@@ -21,6 +21,7 @@ import com.cra.figaro.algorithm.sampling.LikelihoodWeighter
 
 class ForwardWeighter(universe: Universe, cache: Cache) extends LikelihoodWeighter(universe, cache) {
   override def rejectionAction() = ()
+  override def setObservation(element: Element[_], obs: Option[_]) = {}
 }
 
 /**

--- a/Figaro/src/main/scala/com/cra/figaro/algorithm/sampling/LikelihoodWeighter.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/algorithm/sampling/LikelihoodWeighter.scala
@@ -186,12 +186,12 @@ class LikelihoodWeighter(universe: Universe, cache: Cache) {
     } else {
       element match {
         case f: CompoundFlip => {
-          element.value = obs.get.asInstanceOf[element.Value]
+          setObservation(element, obs)
           if (obs.get.asInstanceOf[Boolean]) currentWeight + math.log(f.prob.value)
           else currentWeight + math.log(1 - f.prob.value)
         }
         case e: HasDensity[_] => {
-          element.value = obs.get.asInstanceOf[element.Value]
+          setObservation(element, obs)
           val density = element.asInstanceOf[HasDensity[element.Value]].density(obs.asInstanceOf[Option[element.Value]].get)
           currentWeight + math.log(density)
         }
@@ -204,6 +204,8 @@ class LikelihoodWeighter(universe: Universe, cache: Cache) {
     nextWeight + element.constraint(element.value)
   }
 
+  protected def setObservation(element: Element[_], obs: Option[_]) = element.value = obs.get.asInstanceOf[element.Value]  
+  
   /* Action to take on a rejection. By default it throws an Importance.Reject exception, but this can be overriden for another behavior */
   protected def rejectionAction(): Unit = throw Importance.Reject
 


### PR DESCRIPTION
ElementSampler was wiping temporary elements during Factor sampling creation, leading to only a single sample taken.
Forward sampling was setting the value of observed elements instead of
generating them fresh, leading to poor sampling in MH.