### PR TITLE
Speed up factor creation time

### DIFF
--- a/Figaro/src/main/scala/com/cra/figaro/algorithm/factored/factors/Factory.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/algorithm/factored/factors/Factory.scala
@@ -24,6 +24,7 @@ import com.cra.figaro.library.compound._
 import com.cra.figaro.library.collection._
 import com.cra.figaro.library.atomic.discrete._
 import scala.reflect.runtime.universe.{typeTag, TypeTag}
+import scala.collection.mutable.HashMap
 
 /**
  * A trait for elements that are able to construct their own Factor.
@@ -432,8 +433,9 @@ object Factory {
     resultFactor
   }
 
-  private val factorCache = scala.collection.mutable.Map[Element[_], List[Factor[Double]]]()
-
+  private val factorCache = new HashMap[Element[_], List[Factor[Double]]]() {
+    override def hashCode = 3
+  }
   /**
    * Construct a Factor without constraints.
    */

--- a/Figaro/src/main/scala/com/cra/figaro/algorithm/factored/factors/Variable.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/algorithm/factored/factors/Variable.scala
@@ -17,6 +17,7 @@ import com.cra.figaro.algorithm._
 import com.cra.figaro.language._
 import scala.collection.mutable.Map
 import com.cra.figaro.algorithm.lazyfactored.{ LazyValues, Extended, ValueSet }
+import scala.collection.mutable.HashMap
 
 /**
  * Variables that appear in factors.
@@ -90,10 +91,14 @@ class InternalChainVariable[U](values: ValueSet[U], val chain: Chain[_,_], val c
 /* Variables generated from sufficient statistics of parameters */
 object Variable {
   // An element should always map to the same variable
-  private val memoMake: Map[Element[_], Variable[_]] = Map()
+  private val memoMake : Map[Element[_], Variable[_]] = new HashMap[Element[_], Variable[_]]() {
+    override def hashCode = 1
+  }
 
   // Make sure to register this map (or replace the memoMake)
-  private val idCache: Map[Element[_], Int] = Map()
+  private val idCache: Map[Element[_], Int] = new HashMap[Element[_], Int]() {
+    override def hashCode = 2
+  }
 
   private var idState: Int = 0
 


### PR DESCRIPTION
Speed up factor creation by using fixed hash codes in certain caches that are registered with universes. This is for #531 