### PR TITLE
Make expectation functions curried for type inference

### DIFF
--- a/Figaro/src/main/scala/com/cra/figaro/algorithm/ProbQueryAlgorithm.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/algorithm/ProbQueryAlgorithm.scala
@@ -127,6 +127,18 @@ trait BaseProbQueryAlgorithm[U[_]]
   }
 
   /**
+    * Return an estimate of the expectation of the function under the marginal probability distribution
+    * of the target.
+    * Throws NotATargetException if called on a target that is not in the list of
+    * targets of the algorithm.
+    * Throws AlgorithmInactiveException if the algorithm is inactive.
+    */
+  def expectation[T](target: U[T])(function: T => Double, c: Any = DummyImplicit): Double = {
+    check(target)
+    doExpectation(target, function)
+  }
+
+  /**
    * Return the mean of the probability density function for the given continuous element.
    */
   def mean(target: U[Double]): Double = {

--- a/Figaro/src/test/scala/com/cra/figaro/test/algorithm/AlgorithmTest.scala
+++ b/Figaro/src/test/scala/com/cra/figaro/test/algorithm/AlgorithmTest.scala
@@ -48,12 +48,12 @@ class AlgorithmTest extends WordSpec with Matchers {
       a.probability(c, true)
       a.stop()
       a.distribution(c)
-      a.expectation(c, (b: Boolean) => 1.0)
+      a.expectation(c)(b => 1.0)
       a.probability(c)(b => true)
       a.probability(c, true)
       a.resume()
       a.distribution(c)
-      a.expectation(c, (b: Boolean) => 1.0)
+      a.expectation(c)(b => 1.0)
       a.probability(c)(b => true)
       a.probability(c, true)
     }
@@ -129,7 +129,7 @@ class AlgorithmTest extends WordSpec with Matchers {
       val a = new SimpleAnytime(c)
       a.start()
       a.stop()
-      val x = a.expectation(c, (b: Boolean) => -1.0)
+      val x = a.expectation(c)(b => -1.0)
       a.expectation(c, (b: Boolean) => -1.0) should equal(x)
       a.kill()
     }
@@ -142,7 +142,7 @@ class AlgorithmTest extends WordSpec with Matchers {
       a.stop()
       a.resume()
       val x = a.expectation(c, (b: Boolean) => -1.0)
-      a.expectation(c, (b: Boolean) => -1.0) should be > (x)
+      a.expectation(c)(b => -1.0) should be > (x)
       a.kill()
     }
 

--- a/Figaro/src/test/scala/com/cra/figaro/test/algorithm/sampling/ImportanceTest.scala
+++ b/Figaro/src/test/scala/com/cra/figaro/test/algorithm/sampling/ImportanceTest.scala
@@ -326,7 +326,7 @@ class ImportanceTest extends WordSpec with Matchers with PrivateMethodTester {
       // Uniform(0,1) is beta(1,1)
       // Result is beta(1 + 16,1 + 4)
       // Expectation is (alpha) / (alpha + beta) = 17/22
-      alg.expectation(b, (d: Double) => d) should be((17.0 / 22.0) +- 0.02)
+      alg.expectation(b)(d => d) should be((17.0 / 22.0) +- 0.02)
       val time1 = System.currentTimeMillis()
       // If likelihood weighting is working, stopping and querying the algorithm should be almost instantaneous
       // If likelihood weighting is not working, stopping and querying the algorithm requires waiting for a non-rejected sample
@@ -428,7 +428,7 @@ class ImportanceTest extends WordSpec with Matchers with PrivateMethodTester {
       // uniform(0,1) is beta(1,1)
       // Result is beta(1 + 1600,1 + 400)
       // Expectation is (alpha) / (alpha + beta) = 1601/2003
-      alg.expectation(beta, (d: Double) => d) should be((1601.0 / 2003.0) +- 0.02)
+      alg.expectation(beta)(d => d) should be((1601.0 / 2003.0) +- 0.02)
       val time1 = System.currentTimeMillis()
       // If likelihood weighting is working, stopping and querying the algorithm should be almost instantaneous
       // If likelihood weighting is not working, stopping and querying the algorithm requires waiting for a non-rejected sample

--- a/Figaro/src/test/scala/com/cra/figaro/test/algorithm/sampling/ParImportanceTest.scala
+++ b/Figaro/src/test/scala/com/cra/figaro/test/algorithm/sampling/ParImportanceTest.scala
@@ -149,7 +149,7 @@ class ParImportanceTest extends WordSpec with Matchers with PrivateMethodTester 
       alg.stop()
       // Result is beta(2 + 16,5 + 4)
       // Expectation is (alpha) / (alpha + beta) = 18/27
-      val exp = alg.expectation("b", (d: Double) => d)
+      val exp = alg.expectation("b")(d => d)
       val time1 = System.currentTimeMillis()
       // If likelihood weighting is working, stopping and querying the algorithm should be almost instantaneous
       // If likelihood weighting is not working, stopping and querying the algorithm requires waiting for a non-rejected sample
@@ -200,7 +200,7 @@ class ParImportanceTest extends WordSpec with Matchers with PrivateMethodTester 
       // uniform(0,1) is beta(1,1)
       // Result is beta(1 + 1600,1 + 400)
       // Expectation is (alpha) / (alpha + beta) = 1601/2003
-      val exp = alg.expectation("beta", (d: Double) => d)
+      val exp = alg.expectation("beta")(d => d)
       val time1 = System.currentTimeMillis()
       // If likelihood weighting is working, stopping and querying the algorithm should be almost instantaneous
       // If likelihood weighting is not working, stopping and querying the algorithm requires waiting for a non-rejected sample

--- a/Figaro/src/test/scala/com/cra/figaro/test/book/chap05/ProductDistribution.scala
+++ b/Figaro/src/test/scala/com/cra/figaro/test/book/chap05/ProductDistribution.scala
@@ -57,7 +57,7 @@ object ProductDistribution {
     val model = new Model(targetPopularity, productQuality, affordability)
     val algorithm = Importance(1000, model.numberBuy)
     algorithm.start()
-    val result = algorithm.expectation(model.numberBuy, (i: Int) => i.toDouble)
+    val result = algorithm.expectation(model.numberBuy)(i=> i.toDouble)
     algorithm.kill()
     result
   }

--- a/Figaro/src/test/scala/com/cra/figaro/test/book/chap06/SalesPrediction.scala
+++ b/Figaro/src/test/scala/com/cra/figaro/test/book/chap06/SalesPrediction.scala
@@ -122,9 +122,9 @@ class SalesPredictionTest extends WordSpec with Matchers {
     algorithm.stop()
 
     val hiresProd0 = algorithm.expectation(numHiresByProduct(0), (n: Int) => n.toDouble)
-    val hiresProd1 = algorithm.expectation(numHiresByProduct(1), (n: Int) => n.toDouble)
+    val hiresProd1 = algorithm.expectation(numHiresByProduct(1))(n => n.toDouble)
     val hiresProd2 = algorithm.expectation(numHiresByProduct(2), (n: Int) => n.toDouble)    
-    val hiresProd3 = algorithm.expectation(numHiresByProduct(3), (n: Int) => n.toDouble)
+    val hiresProd3 = algorithm.expectation(numHiresByProduct(3))(n => n.toDouble)
     val hiresProd4 = algorithm.expectation(numHiresByProduct(4), (n: Int) => n.toDouble)
 
     algorithm.kill()

--- a/Figaro/src/test/scala/com/cra/figaro/test/book/chap12/JointDistribution.scala
+++ b/Figaro/src/test/scala/com/cra/figaro/test/book/chap12/JointDistribution.scala
@@ -64,7 +64,7 @@ class JointDistributionTest extends WordSpec with Matchers {
   val secondSales = ve.probability(JointDistribution.sales(1))(_ < 100)
   val bothSales = ve.probability(salesPair, (pair: (Int, Int)) => pair._1 < 100 && pair._2 < 100)
   val totalSales = imp.probability(JointDistribution.totalSales)(_ < 2000)
-  val meanIndSales = ve.expectation(JointDistribution.sales(0), (i: Int) => i.toDouble)
+  val meanIndSales = ve.expectation(JointDistribution.sales(0))(i => i.toDouble)
   val meanTotSales = imp.expectation(JointDistribution.totalSales, (i: Int) => i.toDouble)
   ve.kill()
   imp.kill()

--- a/Figaro/src/test/scala/com/cra/figaro/test/experimental/particlebp/PBPTest.scala
+++ b/Figaro/src/test/scala/com/cra/figaro/test/experimental/particlebp/PBPTest.scala
@@ -331,7 +331,7 @@ class PBPTest extends WordSpec with Matchers {
       })
       val algorithm = ParticleBeliefPropagation(10, 4, 15, 15, loc, locX, locY)
       algorithm.start()
-      val locE = algorithm.expectation(loc, (d: (Double, Double)) => d._1 * d._2)
+      val locE = algorithm.expectation(loc)(d => d._1 * d._2)
       val cov = locE - algorithm.mean(locX) * algorithm.mean(locY)
 
       ParticleGenerator.clear

--- a/FigaroExamples/src/main/scala/com/cra/figaro/example/CarAndEngine.scala
+++ b/FigaroExamples/src/main/scala/com/cra/figaro/example/CarAndEngine.scala
@@ -55,7 +55,7 @@ object CarAndEngine {
     val alg = VariableElimination(car.speed)
     alg.start()
     alg.stop()
-    println(alg.expectation(car.speed, (d: Double) => d))
+    println(alg.expectation(car.speed)(d => d))
     alg.kill()
   }
 }


### PR DESCRIPTION
This PR addresses same type inference issue with `expectation` function. Left some tests as they are to verify these changes are backward compatible 