### PR TITLE
Create new package "extensions" and use it for an improved API

### DIFF
--- a/Figaro/src/main/scala/com/cra/figaro/extensions/Apply.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/extensions/Apply.scala
@@ -1,11 +1,13 @@
-package com.cra.figaro.language
+package com.cra.figaro.extensions
+
+import com.cra.figaro.language._
 
 /**
   * This class is a workaround for adding easier type inference to Apply class
   * Since Apply object is already using apply method with different number of arguments
   * it is not easy to find a workaround adding currying support to apply methods in Apply class
   */
-object ApplyC {
+object Apply {
   /**
     * Application of a function to one argument.
     */

--- a/Figaro/src/main/scala/com/cra/figaro/extensions/CPD.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/extensions/CPD.scala
@@ -1,0 +1,117 @@
+package com.cra.figaro.extensions
+
+/*
+ * CPD.scala
+ * Conditional probability distributions.
+ *
+ * Created By:      Cagdas Senol (cagdassenol@gmail.com)
+ * Creation Date:   May 18, 2016
+ *
+ * Copyright 2013 Avrom J. Pfeffer and Charles River Analytics, Inc.
+ * See http://www.cra.com or email figaro@cra.com for information.
+ *
+ * See http://www.github.com/p2t2/figaro for a copy of the software license.
+ */
+
+
+import com.cra.figaro.language.CachingChain
+import com.cra.figaro.language.Element
+import com.cra.figaro.language.ElementCollection
+import com.cra.figaro.language.Name
+import com.cra.figaro.library.compound.^^
+
+/**
+  * A conditional probability distribution with one parent.
+  */
+class CPD1[T1, U](name: Name[U], arg1: Element[T1], clauses: PartialFunction[T1, Element[U]], collection: ElementCollection)
+  extends CachingChain[T1, U](name, arg1, (t1: T1) => clauses(t1), collection)
+
+/**
+  * A conditional probability distribution with two parents.
+  */
+class CPD2[T1, T2, U](name: Name[U], arg1: Element[T1], arg2: Element[T2],
+                      clauses: PartialFunction[(T1, T2), Element[U]], collection: ElementCollection)
+  extends CachingChain[(T1, T2), U](
+    name,
+    ^^(arg1, arg2)("", collection),
+    (p: (T1, T2)) => clauses(p),
+    collection)
+
+/**
+  * A conditional probability distribution with three parents.
+  */
+class CPD3[T1, T2, T3, U](name: Name[U], arg1: Element[T1], arg2: Element[T2], arg3: Element[T3],
+                          clauses: PartialFunction[(T1, T2, T3), Element[U]], collection: ElementCollection)
+  extends CachingChain[(T1, T2, T3), U](
+    name,
+    ^^(arg1, arg2, arg3)("", collection),
+    (p: (T1, T2, T3)) => clauses(p),
+    collection)
+
+/**
+  * A conditional probability distribution with four parents.
+  */
+class CPD4[T1, T2, T3, T4, U](name: Name[U], arg1: Element[T1], arg2: Element[T2], arg3: Element[T3], arg4: Element[T4],
+                              clauses: PartialFunction[(T1, T2, T3, T4), Element[U]], collection: ElementCollection)
+  extends CachingChain[(T1, T2, T3, T4), U](
+    name,
+    ^^(arg1, arg2, arg3, arg4)("", collection),
+    (p: (T1, T2, T3, T4)) => clauses(p),
+    collection)
+
+/**
+  * A conditional probability distribution with five parents.
+  */
+class CPD5[T1, T2, T3, T4, T5, U](name: Name[U], arg1: Element[T1], arg2: Element[T2], arg3: Element[T3], arg4: Element[T4],
+                                  arg5: Element[T5], clauses: PartialFunction[(T1, T2, T3, T4, T5), Element[U]], collection: ElementCollection)
+  extends CachingChain[(T1, T2, T3, T4, T5), U](
+    name,
+    ^^(arg1, arg2, arg3, arg4, arg5)("", collection),
+    (p: (T1, T2, T3, T4, T5)) => clauses(p),
+    collection)
+
+object CPD {
+  /**
+    * Create a CPD with one parent.
+    *
+    * @param clauses A sequence of (condition, Element) pairs, where the condition specifies a value of the parent
+    */
+  def apply[T1, U](arg1: Element[T1])(clauses: PartialFunction[T1, Element[U]])(implicit name: Name[U], collection: ElementCollection) =
+    new CPD1(name, arg1, clauses, collection)
+
+  /**
+    * Create a CPD with two parents.
+    *
+    * @param clauses A sequence of (condition, Element) pairs, where the condition specifies a value of the parents
+    */
+  def apply[T1, T2, U](arg1: Element[T1], arg2: Element[T2])(clauses: PartialFunction[(T1, T2), Element[U]])(implicit name: Name[U], collection: ElementCollection) =
+    new CPD2(name, arg1, arg2, clauses, collection)
+
+  /**
+    * Create a CPD with three parents.
+    *
+    * @param clauses A sequence of (condition, Element) pairs, where the condition specifies a value of the parents
+    */
+  def apply[T1, T2, T3, U](arg1: Element[T1], arg2: Element[T2], arg3: Element[T3])(
+                           clauses: PartialFunction[(T1, T2, T3), Element[U]])(implicit name: Name[U], collection: ElementCollection) =
+    new CPD3(name, arg1, arg2, arg3, clauses, collection)
+
+  /**
+    * Create a CPD with four parents.
+    *
+    * @param clauses A sequence of (condition, Element) pairs, where the condition specifies a value of the parents
+    */
+  def apply[T1, T2, T3, T4, U](arg1: Element[T1], arg2: Element[T2], arg3: Element[T3], arg4: Element[T4])(
+                               clauses: PartialFunction[(T1, T2, T3, T4), Element[U]])(implicit name: Name[U], collection: ElementCollection) =
+    new CPD4(name, arg1, arg2, arg3, arg4, clauses, collection)
+
+  /**
+    * Create a CPD with five parents.
+    *
+    * @param clauses A sequence of (condition, Element) pairs, where the condition specifies a value of the parents
+    */
+  def apply[T1, T2, T3, T4, T5, U](arg1: Element[T1], arg2: Element[T2], arg3: Element[T3], arg4: Element[T4],
+                                   arg5: Element[T5])(clauses: PartialFunction[(T1, T2, T3, T4, T5), Element[U]])(implicit name: Name[U], collection: ElementCollection) =
+    new CPD5(name, arg1, arg2, arg3, arg4, arg5, clauses, collection)
+
+}

--- a/Figaro/src/main/scala/com/cra/figaro/extensions/Chain.scala
+++ b/Figaro/src/main/scala/com/cra/figaro/extensions/Chain.scala
@@ -1,0 +1,58 @@
+package com.cra.figaro.extensions
+
+import com.cra.figaro.language._
+
+object Chain {
+  /**
+    * Create a chain of 1 argument.
+    * The Chain factory constructor chooses either a CachingChain or NonCachingChain depending on the cacheability of the parent.
+    * The parent's cacheability is determined by the parent.isCachable field. This is normally determined by the type of the element.
+    */
+  def apply[T, U](parent: Element[T])(cpd: T => Element[U])(implicit name: Name[U], collection: ElementCollection): Chain[T, U] = {
+    if (parent.isCachable) new CachingChain(name, parent, cpd, collection)
+    else new NonCachingChain(name, parent, cpd, collection)
+  }
+
+  /**
+    * Create a chain of 2 arguments. This is implemented as a chain on the single argument consisting of the pair of the two arguments.
+    * If both arguments are cachable, a CachingChain will be produced, otherwise a NonCaching chain.
+    */
+  def apply[T1, T2, U](parent1: Element[T1], parent2: Element[T2])(cpd: (T1, T2) => Element[U])(implicit name: Name[U], collection: ElementCollection): Chain[(T1, T2), U] = {
+    val parentTuple = new Apply2("", parent1, parent2, (t1: T1, t2: T2) => (t1, t2), collection)
+    if (parentTuple.isCachable) new CachingChain(name, parentTuple, (p: (T1, T2)) => cpd(p._1, p._2), collection)
+    else new NonCachingChain(name, parentTuple, (p: (T1, T2)) => cpd(p._1, p._2), collection)
+  }
+
+}
+
+object CachingChain {
+
+  /** Create a CachingChain of 1 argument. */
+  def apply[T, U](parent: Element[T])(cpd: T => Element[U])(implicit name: Name[U], collection: ElementCollection): CachingChain[T, U] =
+    new CachingChain(name, parent, cpd, collection)
+
+  /**
+    * Create a CachingChain of 2 arguments. This is implemented as a chain on the single argument consisting of the pair of the two arguments.
+    */
+  def apply[T1, T2, U](parent1: Element[T1], parent2: Element[T2])(cpd: (T1, T2) => Element[U])(implicit name: Name[U], collection: ElementCollection): CachingChain[(T1, T2), U] = {
+    new CachingChain(
+      name,
+      new Apply2("", parent1, parent2, (t1: T1, t2: T2) => (t1, t2), collection),
+      (pair: (T1, T2)) => cpd(pair._1, pair._2),
+      collection)
+  }
+}
+
+object NonCachingChain {
+  /** Create a NonCaching chain of 1 argument. */
+  def apply[T, U](parent: Element[T])(cpd: T => Element[U])(implicit name: Name[U], collection: ElementCollection): NonCachingChain[T, U] =
+    new NonCachingChain(name, parent, cpd, collection)
+
+  /** Create a NonCaching chain of 2 arguments. This is implemented as a chain on the single argument consisting of the pair of the two arguments. */
+  def apply[T1, T2, U](parent1: Element[T1], parent2: Element[T2])(cpd: (T1, T2) => Element[U])(implicit name: Name[U], collection: ElementCollection): NonCachingChain[(T1, T2), U] =
+    new NonCachingChain(
+      name,
+      new Apply2("", parent1, parent2, (t1: T1, t2: T2) => (t1, t2), collection),
+      (pair: (T1, T2)) => cpd(pair._1, pair._2),
+      collection)
+}

--- a/Figaro/src/test/scala/com/cra/figaro/test/extensions/ApplyTest.scala
+++ b/Figaro/src/test/scala/com/cra/figaro/test/extensions/ApplyTest.scala
@@ -1,0 +1,102 @@
+package com.cra.figaro.test.extensions
+
+
+import com.cra.figaro.extensions.Apply
+import com.cra.figaro.language.{Select, Constant, Universe}
+import com.cra.figaro.library.atomic.discrete.Uniform
+import org.scalatest.Matchers
+import org.scalatest.WordSpec
+
+class ApplyTest extends WordSpec with Matchers {
+
+
+  "An extension Apply with one argument" should {
+    "have value equal to its function applied to its argument" in {
+      Universe.createNew()
+      val u = Uniform(0.0, 2.0)
+      val a = Apply(u)(_ + 1.0)
+      u.value = 1.3
+      a.generate()
+      a.value should equal(2.3)
+    }
+
+    "convert to the correct string" in {
+      Universe.createNew()
+      val u = Uniform(0.0, 2.0)
+      val f = (d: Double) => d + 1.0
+      Apply(u)(f).toString should equal("Apply(" + u + ", " + f + ")")
+    }
+
+  }
+
+  "An extension Apply with two arguments" should {
+    "have value equal to its function applied to its arguments" in {
+      Universe.createNew()
+      val u = Uniform(0.0, 2.0)
+      val v = Constant(1.0)
+      val a = Apply(u, v)( _ + _ + 1.0)
+      u.value = 1.3
+      v.value = 1.0
+      a.generate()
+      a.value should equal(3.3)
+    }
+
+    "convert to the correct string" in {
+      val u = Uniform(0.0, 2.0)
+      val v = Constant(1.0)
+      val f = (d1: Double, d2: Double) => d1 + d2 + 1.0
+      Apply(u, v)(f).toString should equal("Apply(" + u + ", " + v + ", " + f + ")")
+    }
+  }
+
+  "An extension Apply with three arguments" should {
+    "have value equal to its function applied to its arguments" in {
+      Universe.createNew()
+      val u = Uniform(0.0, 2.0)
+      val v = Constant(1.0)
+      val w = Select(0.5 -> 0.0, 0.5 -> 5.0)
+      val a = Apply(u, v, w)(_ + _ + _ + 1.0)
+      u.value = 1.3
+      v.value = 1.0
+      w.value = 5.0
+      a.generate()
+      a.value should equal(8.3)
+    }
+
+    "convert to the correct string" in {
+      val u = Uniform(0.0, 2.0)
+      val v = Constant(1.0)
+      val w = Select(0.5 -> 0.0, 0.5 -> 5.0)
+      val f = (d1: Double, d2: Double, d3: Double) => d1 + d2 + d3 + 1.0
+      Apply(u, v, w)(f).toString should equal(
+        "Apply(" + u + ", " + v + ", " + w + ", " + f + ")")
+    }
+  }
+
+  "An extension Apply with four arguments" should {
+    "have value equal to its function applied to its arguments" in {
+      Universe.createNew()
+      val u = Uniform(0.0, 2.0)
+      val v = Constant(1.0)
+      val w = Select(0.5 -> 0.0, 0.5 -> 5.0)
+      val x = Constant(-2.0)
+      val a = Apply(u, v, w, x)(_ + _ + _ + _ + 1.0)
+      u.value = 1.3
+      v.value = 1.0
+      w.value = 5.0
+      x.value = -2.0
+      a.generate()
+      a.value should equal(6.3)
+    }
+
+    "convert to the correct string" in {
+      val u = Uniform(0.0, 2.0)
+      val v = Constant(1.0)
+      val w = Select(0.5 -> 0.0, 0.5 -> 5.0)
+      val x = Constant(-2.0)
+      val f = (d1: Double, d2: Double, d3: Double, d4: Double) => d1 + d2 + d3 + d4 + 1.0
+      Apply(u, v, w, x)(f).toString should equal(
+        "Apply(" + u + ", " + v + ", " + w + ", " + x + ", " + f + ")")
+    }
+  }
+}

--- a/Figaro/src/test/scala/com/cra/figaro/test/extensions/ChainTest.scala
+++ b/Figaro/src/test/scala/com/cra/figaro/test/extensions/ChainTest.scala
@@ -1,0 +1,146 @@
+package com.cra.figaro.test.extensions
+
+
+
+import com.cra.figaro.extensions.{CachingChain, Chain, NonCachingChain}
+import com.cra.figaro.language.{Chain => _, CachingChain => _, NonCachingChain => _, _}
+import com.cra.figaro.library.atomic.discrete.Uniform
+import org.scalatest.Matchers
+import org.scalatest.WordSpec
+
+class ChainTest extends WordSpec with Matchers {
+
+  "A Chain" when {
+    "called" should {
+      "have value equal to the value of its function applied to its argument's value" in {
+        Universe.createNew()
+        val f1 = Flip(0.7)
+        val f2 = Flip(0.4)
+        val f3 = Flip(0.9)
+        val c = NonCachingChain(f1)(b => if(b) f2; else f3)
+        f1.value = false
+        f2.value = true
+        f3.value = false
+        c.generate()
+        c.value should equal(false)
+        f1.value = true
+        c.generate()
+        c.value should equal(true)
+      }
+
+      "convert to the correct string" in {
+        Universe.createNew()
+        val f1 = Flip(0.7)
+        val f2 = Flip(0.4)
+        val f3 = Flip(0.9)
+        val fn = (b: Boolean) => if (b) f2; else f3
+        NonCachingChain(f1)(fn).toString should equal("Chain(" + f1 + ", " + fn + ")")
+      }
+
+      "call the CPD for each Chain access" in {
+        Universe.createNew()
+        var sum = 0
+        def fn(b: Int) = {
+          sum += 1
+          Constant(b)
+        }
+        val f1 = Uniform(0, 1, 2)
+        val c = NonCachingChain(f1)(fn)
+        sum = 0
+        c.get(0)
+        c.get(1)
+        c.get(2)
+        c.get(0)
+        sum should equal(4)
+      }
+    }
+
+  }
+
+  "A chain with two parents" when {
+    "non-caching" should {
+      "have value equal to the value of its function applied to its argument's values" in {
+        Universe.createNew()
+        val f1 = Flip(0.4)
+        val f2 = Flip(0.7)
+        val f3 = Flip(0.9)
+        val f4 = Flip(0.235)
+        val c = NonCachingChain(f1, f2)((b1, b2) => if (b1 && b2 ) f3; else f4)
+        f1.set(false)
+        f2.set(true)
+        f3.set(false)
+        f4.set(true)
+        c.generate()
+        c.value should equal(true)
+
+        f1.set(true)
+        c.generate()
+        c.value should equal(false)
+
+      }
+
+      "convert to the correct string" in {
+        Universe.createNew()
+        val f1 = Flip(0.7)
+        val f2 = Flip(0.4)
+        val f3 = Flip(0.9)
+        val f4 = Flip(0.235)
+        val fn = (b1: Boolean, b2: Boolean) => if (b1 && b2) f3; else f4
+        NonCachingChain(f1, f2)(fn).toString should equal("Chain(Apply(" + f1 + ", " + f2 + ", " + fn + "), <function1>)")
+      }
+
+      "evaluate the CPD each time get is called" in {
+        Universe.createNew()
+        var sum = 0
+        def fn(b1: Boolean, b2: Boolean): Element[Boolean] = {
+          sum += 1
+          Constant(b1 && b2)
+        }
+        val f1 = Flip(0.5)
+        val f2 = Flip(0.5)
+        f1.set(true)
+        f2.set(false)
+        val c = Chain(f1, f2)(fn)
+        c.get(true, true)
+        c.get(false, false)
+        c.get(true, true)
+        sum should equal(3)
+      }
+    }
+
+    "caching" should {
+      "have value equal to the value of its function applied to its argument's value" in {
+        Universe.createNew()
+        val f1 = Flip(0.7)
+        val f2 = Flip(0.4)
+        val f3 = Flip(0.9)
+        val f4 = Flip(0.235)
+        f1.set(false)
+        f2.set(true)
+        f3.set(false)
+        f4.set(true)
+        val c = CachingChain(f1, f2)((b1, b2) => if (b1  && b2 ) f3; else f4)
+
+        c.generate()
+        c.value should equal(true)
+        f1.set(true)
+        c.generate()
+        c.value should equal(false)
+      }
+
+      "convert to the correct string" in {
+        Universe.createNew()
+        val f1 = Flip(0.7)
+        val f2 = Flip(0.4)
+        val f3 = Flip(0.9)
+        val f4 = Flip(0.235)
+        val fn = (b1: Boolean, b2: Boolean) => if (b1 && b2) f3; else f4
+        //      "Chain(Apply(Flip(0.7), Flip(0.4), <function2>), <function1>)"
+
+        CachingChain(f1, f2)(fn).toString should equal("Chain(Apply(" + f1 + ", " + f2 + ", " + fn + "), <function1>)")
+      }
+      //((((((((((80 * .50) * 1.08) + 82.4 * .50) * 1.08) + 84.8 * .50) * 1.08) + 87.3 * .50) * 1.08) + 89.9 * .50) * 1.08)
+
+    }
+  }
+}

--- a/Figaro/src/test/scala/com/cra/figaro/test/extensions/CompoundTest.scala
+++ b/Figaro/src/test/scala/com/cra/figaro/test/extensions/CompoundTest.scala
@@ -1,0 +1,335 @@
+package com.cra.figaro.test.extensions
+
+import com.cra.figaro.algorithm.factored.VariableElimination
+import com.cra.figaro.extensions.CPD
+import com.cra.figaro.language._
+import com.cra.figaro.library.compound.{CPD => _, _}
+import org.scalatest.Matchers
+import org.scalatest.WordSpec
+
+class CompoundTest extends WordSpec with Matchers {
+  "A CPD with one argument" should {
+    "produce a result with the expectation over the parent of the probability of the child" in {
+      Universe.createNew()
+      val x = Flip(0.2)
+      val y = CPD(x) {
+        case false => Flip(0.1)
+        case true => Flip(0.7)
+      }
+      val alg = VariableElimination(y)
+      alg.start()
+      alg.probability(y, true) should be((0.2 * 0.7 + 0.8 * 0.1) +- 0.00000000001)
+    }
+
+    "throw MatchError if no clause exists for a given parent value" in {
+      Universe.createNew()
+      val x = Flip(0.2)
+      an [MatchError] should be thrownBy {
+        val y = CPD(x){
+          case true => Flip(0.7)
+        }
+        val alg = VariableElimination(y)
+        alg.start()
+      }
+    }
+  }
+
+  "A CPD with two arguments" should {
+    "produce a result with the expectation over the parents of the probability of the child" in {
+      Universe.createNew()
+      val x1 = Flip(0.2)
+      val x2 = Select(0.2 -> 1, 0.3 -> 2, 0.5 -> 3)
+      val y = CPD(x1, x2) {
+        case (false, 1) => Flip(0.1)
+        case (false, 2) => Flip(0.2)
+        case (false, 3) => Flip(0.3)
+        case (true, 1) => Flip(0.4)
+        case (true, 2) => Flip(0.5)
+        case (true, 3) => Flip(0.6)
+      }
+      val alg = VariableElimination(y)
+      alg.start()
+      alg.probability(y, true) should be((0.2 * (0.2 * 0.4 + 0.3 * 0.5 + 0.5 * 0.6) +
+        0.8 * (0.2 * 0.1 + 0.3 * 0.2 + 0.5 * 0.3)) +- 0.00000000001)
+    }
+
+    "throw MatchError if no clause exists for a given parent value" in {
+      Universe.createNew()
+      val x1 = Flip(0.2)
+      val x2 = Select(0.2 -> 1, 0.3 -> 2, 0.5 -> 3)
+      an [MatchError] should be thrownBy {
+        val y = CPD(x1, x2) {
+          case (false, 1) => Flip(0.1)
+          case (false, 3) => Flip(0.3)
+          case (true, 1) => Flip(0.4)
+          case (true, 2) => Flip(0.5)
+          case (true, 3) => Flip(0.6)
+        }
+        val alg = VariableElimination(y)
+        alg.start()
+      }
+    }
+  }
+
+  "A CPD with three arguments" should {
+    "produce a result with the expectation over the parents of the probability of the child" in {
+      Universe.createNew()
+      val x1 = Flip(0.2)
+      val x2 = Select(0.2 -> 1, 0.3 -> 2, 0.5 -> 3)
+      val x3 = Constant(7)
+      val y = CPD(x1, x2, x3) {
+        case (false, 1, 7) => Flip(0.1)
+        case (false, 2, 7) => Flip(0.2)
+        case (false, 3, 7) => Flip(0.3)
+        case (true, 1, 7) => Flip(0.4)
+        case (true, 2, 7) => Flip(0.5)
+        case (true, 3, 7) => Flip(0.6)
+      }
+      val alg = VariableElimination(y)
+      alg.start()
+      alg.probability(y, true) should be((0.2 * (0.2 * 0.4 + 0.3 * 0.5 + 0.5 * 0.6) +
+        0.8 * (0.2 * 0.1 + 0.3 * 0.2 + 0.5 * 0.3)) +- 0.00000000001)
+    }
+
+    "throw MatchError if no clause exists for a given parent value" in {
+      Universe.createNew()
+      val x1 = Flip(0.2)
+      val x2 = Select(0.2 -> 1, 0.3 -> 2, 0.5 -> 3)
+      val x3 = Constant(7)
+      an [MatchError] should be thrownBy {
+        val y = CPD(x1, x2, x3) {
+          case (false, 1, 7) => Flip(0.1)
+          case (false, 3, 7) => Flip(0.3)
+          case (true, 1, 7) => Flip(0.4)
+          case (true, 2, 7) => Flip(0.5)
+          case (true, 3, 7) => Flip(0.6)
+        }
+        val alg = VariableElimination(y)
+        alg.start()
+      }
+    }
+  }
+
+  "A CPD with four arguments" should {
+    "produce a result with the expectation over the parents of the probability of the child" in {
+      Universe.createNew()
+      val x1 = Flip(0.2)
+      val x2 = Select(0.2 -> 1, 0.3 -> 2, 0.5 -> 3)
+      val x3 = Constant(7)
+      val x4 = Flip(0.9)
+      val y = CPD(x1, x2, x3, x4) {
+        case (false, 1, 7, false) => Flip(0.1)
+        case (false, 2, 7, false) => Flip(0.2)
+        case (false, 3, 7, false) => Flip(0.3)
+        case (true, 1, 7, false) => Flip(0.4)
+        case (true, 2, 7, false) => Flip(0.5)
+        case (true, 3, 7, false) => Flip(0.6)
+        case (false, 1, 7, true) => Flip(0.15)
+        case (false, 2, 7, true) => Flip(0.25)
+        case (false, 3, 7, true) => Flip(0.35)
+        case (true, 1, 7, true) => Flip(0.45)
+        case (true, 2, 7, true) => Flip(0.55)
+        case (true, 3, 7, true) => Flip(0.65)
+      }
+      val alg = VariableElimination(y)
+      alg.start()
+      alg.probability(y, true) should be((0.2 * 0.9 * (0.2 * 0.45 + 0.3 * 0.55 + 0.5 * 0.65) +
+        0.2 * 0.1 * (0.2 * 0.4 + 0.3 * 0.5 + 0.5 * 0.6) +
+        0.8 * 0.9 * (0.2 * 0.15 + 0.3 * 0.25 + 0.5 * 0.35) +
+        0.8 * 0.1 * (0.2 * 0.1 + 0.3 * 0.2 + 0.5 * 0.3))
+        +- 0.00000000001)
+    }
+
+    "throw MatchError if no clause exists for a given parent value" in {
+      Universe.createNew()
+      val x1 = Flip(0.2)
+      val x2 = Select(0.2 -> 1, 0.3 -> 2, 0.5 -> 3)
+      val x3 = Constant(7)
+      val x4 = Flip(0.9)
+      an [MatchError] should be thrownBy {
+        val y = CPD(x1, x2, x3, x4) {
+          case (false, 1, 7, false) => Flip(0.1)
+          case (false, 3, 7, false) => Flip(0.3)
+          case (true, 1, 7, false) => Flip(0.4)
+          case (true, 2, 7, false) => Flip(0.5)
+          case (true, 3, 7, false) => Flip(0.6)
+          case (false, 1, 7, true) => Flip(0.15)
+          case (false, 2, 7, true) => Flip(0.25)
+          case (false, 3, 7, true) => Flip(0.35)
+          case (true, 1, 7, true) => Flip(0.45)
+          case (true, 2, 7, true) => Flip(0.55)
+          case (true, 3, 7, true) => Flip(0.65)
+        }
+        val alg = VariableElimination(y)
+        alg.start()
+      }
+    }
+  }
+
+  "A CPD with five arguments" should {
+    "produce a result with the expectation over the parents of the probability of the child" in {
+      Universe.createNew()
+      val x1 = Flip(0.2)
+      val x2 = Select(0.2 -> 1, 0.3 -> 2, 0.5 -> 3)
+      val x3 = Constant(7)
+      val x4 = Flip(0.9)
+      val x5 = Constant('a)
+      val y = CPD(x1, x2, x3, x4, x5) {
+        case (false, 1, 7, false, 'a) => Flip(0.1)
+        case (false, 2, 7, false, 'a) => Flip(0.2)
+        case (false, 3, 7, false, 'a) => Flip(0.3)
+        case (true, 1, 7, false, 'a) => Flip(0.4)
+        case (true, 2, 7, false, 'a) => Flip(0.5)
+        case (true, 3, 7, false, 'a) => Flip(0.6)
+        case (false, 1, 7, true, 'a) => Flip(0.15)
+        case (false, 2, 7, true, 'a) => Flip(0.25)
+        case (false, 3, 7, true, 'a) => Flip(0.35)
+        case (true, 1, 7, true, 'a) => Flip(0.45)
+        case (true, 2, 7, true, 'a) => Flip(0.55)
+        case (true, 3, 7, true, 'a) => Flip(0.65)
+      }
+      val alg = VariableElimination(y)
+      alg.start()
+      alg.probability(y, true) should be((0.2 * 0.9 * (0.2 * 0.45 + 0.3 * 0.55 + 0.5 * 0.65) +
+        0.2 * 0.1 * (0.2 * 0.4 + 0.3 * 0.5 + 0.5 * 0.6) +
+        0.8 * 0.9 * (0.2 * 0.15 + 0.3 * 0.25 + 0.5 * 0.35) +
+        0.8 * 0.1 * (0.2 * 0.1 + 0.3 * 0.2 + 0.5 * 0.3))
+        +- 0.00000000001)
+    }
+
+    "throw MatchError if no clause exists for a given parent value" in {
+      Universe.createNew()
+      val x1 = Flip(0.2)
+      val x2 = Select(0.2 -> 1, 0.3 -> 2, 0.5 -> 3)
+      val x3 = Constant(7)
+      val x4 = Flip(0.9)
+      val x5 = Constant('a)
+      an [MatchError] should be thrownBy {
+        val y = CPD(x1, x2, x3, x4, x5) {
+          case (false, 1, 7, false, 'a) => Flip(0.1)
+          case (false, 3, 7, false, 'a) => Flip(0.3)
+          case (true, 1, 7, false, 'a) => Flip(0.4)
+          case (true, 2, 7, false, 'a) => Flip(0.5)
+          case (true, 3, 7, false, 'a) => Flip(0.6)
+          case (false, 1, 7, true, 'a) => Flip(0.15)
+          case (false, 2, 7, true, 'a) => Flip(0.25)
+          case (false, 3, 7, true, 'a) => Flip(0.35)
+          case (true, 1, 7, true, 'a) => Flip(0.45)
+          case (true, 2, 7, true, 'a) => Flip(0.55)
+          case (true, 3, 7, true, 'a) => Flip(0.65)
+        }
+        val alg = VariableElimination(y)
+        alg.start()
+      }
+    }
+  }
+
+  "A Rich CPD with one argument" should {
+    "produce a result with the expectation over the parent of the probability of the child" in {
+      Universe.createNew()
+      val x = Select(0.1 -> 1, 0.2 -> 2, 0.3 -> 3, 0.4 -> 4)
+      val y = CPD(x) {
+        case k if Set(1, 2)(k) => Flip(0.1)
+        case k if k != 4 => Flip(0.7)
+        case _ => Flip(0.9)
+      }
+      val alg = VariableElimination(y)
+      alg.start()
+      alg.probability(y, true) should be(((0.1 + 0.2) * 0.1 + 0.3 * 0.7 + 0.4 * 0.9) +- 0.00000000001)
+    }
+  }
+
+  "A Rich CPD with two arguments" should {
+    "produce a result with the expectation over the parent of the probability of the child" in {
+      Universe.createNew()
+      val x1 = Select(0.1 -> 1, 0.2 -> 2, 0.3 -> 3, 0.4 -> 4)
+      val x2 = Flip(0.6)
+      val y = CPD(x1, x2) {
+        case (k1, k2) if Set(1, 2)(k1) => Flip(0.1)
+        case (k1, k2) if k1 != 4 && !k2 => Flip(0.7)
+        case (_, _) => Flip(0.9)
+      }
+      val alg = VariableElimination(y)
+      alg.start()
+      alg.probability(y, true) should be(((0.1 + 0.2) * 0.1 + 0.3 * 0.4 * 0.7 + (0.3 * 0.6 + 0.4) * 0.9)
+        +- 0.00000000001)
+    }
+  }
+
+  "A Rich CPD with three arguments" should {
+    "produce a result with the expectation over the parent of the probability of the child" in {
+      Universe.createNew()
+      val x1 = Select(0.1 -> 1, 0.2 -> 2, 0.3 -> 3, 0.4 -> 4)
+      val x2 = Flip(0.6)
+      val x3 = Constant(5)
+      val y: Element[Boolean] = CPD(x1, x2, x3) {
+        case (k1, _, k3) if Set(1,2)(k1) && k3 == 5 => Flip(0.1)
+        case (k1, k2, _) if k1 != 4 && !k2 => Flip(0.7)
+        case (_, _, k3) if !Set(6, 7)(k3) => Flip(0.9)
+      }
+      val alg = VariableElimination(y)
+      alg.start()
+      alg.probability(y, true) should be(((0.1 + 0.2) * 0.1 + 0.3 * 0.4 * 0.7 + (0.3 * 0.6 + 0.4) * 0.9)
+        +- 0.00000000001)
+    }
+  }
+
+  "A Rich CPD with four arguments" should {
+    "produce a result with the expectation over the parent of the probability of the child" in {
+      Universe.createNew()
+      val x1 = Select(0.1 -> 1, 0.2 -> 2, 0.3 -> 3, 0.4 -> 4)
+      val x2 = Flip(0.6)
+      val x3 = Constant(5)
+      val x4 = Flip(0.8)
+      val y = CPD(x1, x2, x3, x4) {
+        case (k1, _, k3, _) if Set(1,2)(k1) && k3 == 5 => Flip(0.1)
+        case (k1, k2, _, _) if k1 != 4 && !k2 => Flip(0.7)
+        case (_, _, k3, k4) if !Set(6,7)(k3) && k4 => Flip(0.9)
+        case (_, _, _, k4) if !k4 => Constant(true)
+      }
+      val alg = VariableElimination(y)
+      alg.start()
+      alg.probability(y, true) should be(((0.1 + 0.2) * 0.1 + 0.3 * 0.4 * 0.7 +
+        (0.3 * 0.6 + 0.4) * (0.8 * 0.9 + 0.2))
+        +- 0.00000000001)
+    }
+  }
+
+  "A Rich CPD with five arguments" should {
+    "produce a result with the expectation over the parent of the probability of the child" in {
+      Universe.createNew()
+      val x1 = Select(0.1 -> 1, 0.2 -> 2, 0.3 -> 3, 0.4 -> 4)
+      val x2 = Flip(0.6)
+      val x3 = Constant(5)
+      val x4 = Flip(0.8)
+      val x5 = Flip(0.5)
+      val y: Element[Boolean] = CPD(x1, x2, x3, x4, x5) {
+        case (k1, _, k3, _, _) if Set(1,2)(k1) && k3 ==5 => Flip(0.1)
+        case (k1, k2, _, _, _) if k1 != 4 && !k2=> Flip(0.7)
+        case (_, _, k3, k4, _) if !Set(6,7)(k3) && k4 => Flip(0.9)
+        case (_, _, _, k4, _) if !k4 => Constant(true)
+      }
+      val alg = VariableElimination(y)
+      alg.start()
+      alg.probability(y, true) should be(((0.1 + 0.2) * 0.1 + 0.3 * 0.4 * 0.7 +
+        (0.3 * 0.6 + 0.4) * (0.8 * 0.9 + 0.2))
+        +- 0.00000000001)
+    }
+  }
+
+  "A Rich CPD using an implicit universe" should {
+    "should add elements automatically to implicit universe instead of default" in {
+      Universe.createNew()
+      val otherUniverse = new Universe
+      implicit val implicitUniverse: Universe = otherUniverse
+      val x = Constant(true)
+      val y = Constant(true)
+      val z: Element[Boolean] = CPD(x, y) {
+        case (k1, _) if k1 => Constant(true)
+        case (k1, _) if !k1=> Constant(false)
+      }
+      Universe.universe.activeElements.size should be(0)
+      otherUniverse.activeElements.size should be(4)
+    }
+  }
+}

--- a/Figaro/src/test/scala/com/cra/figaro/test/language/ElementsTest.scala
+++ b/Figaro/src/test/scala/com/cra/figaro/test/language/ElementsTest.scala
@@ -311,25 +311,6 @@ class ElementsTest extends WordSpec with Matchers {
     }
   }
 
-  "An ApplyC with one argument" should {
-    "have value equal to its function applied to its argument" in {
-      Universe.createNew()
-      val u = Uniform(0.0, 2.0)
-      val a = ApplyC(u)(_ + 1.0)
-      u.value = 1.3
-      a.generate()
-      a.value should equal(2.3)
-    }
-
-    "convert to the correct string" in {
-      Universe.createNew()
-      val u = Uniform(0.0, 2.0)
-      val f = (d: Double) => d + 1.0
-      ApplyC(u)(f).toString should equal("Apply(" + u + ", " + f + ")")
-    }
-
-  }
-
   "An Apply with two arguments" should {
     "have value equal to its function applied to its arguments" in {
       Universe.createNew()
@@ -347,26 +328,6 @@ class ElementsTest extends WordSpec with Matchers {
       val v = Constant(1.0)
       val f = (d1: Double, d2: Double) => d1 + d2 + 1.0
       Apply(u, v, f).toString should equal("Apply(" + u + ", " + v + ", " + f + ")")
-    }
-  }
-
-  "An ApplyC with two arguments" should {
-    "have value equal to its function applied to its arguments" in {
-      Universe.createNew()
-      val u = Uniform(0.0, 2.0)
-      val v = Constant(1.0)
-      val a = ApplyC(u, v)( _ + _ + 1.0)
-      u.value = 1.3
-      v.value = 1.0
-      a.generate()
-      a.value should equal(3.3)
-    }
-
-    "convert to the correct string" in {
-      val u = Uniform(0.0, 2.0)
-      val v = Constant(1.0)
-      val f = (d1: Double, d2: Double) => d1 + d2 + 1.0
-      ApplyC(u, v)(f).toString should equal("Apply(" + u + ", " + v + ", " + f + ")")
     }
   }
 
@@ -395,30 +356,6 @@ class ElementsTest extends WordSpec with Matchers {
     }
   }
 
-  "An ApplyC with three arguments" should {
-    "have value equal to its function applied to its arguments" in {
-      Universe.createNew()
-      val u = Uniform(0.0, 2.0)
-      val v = Constant(1.0)
-      val w = Select(0.5 -> 0.0, 0.5 -> 5.0)
-      val a = ApplyC(u, v, w)(_ + _ + _ + 1.0)
-      u.value = 1.3
-      v.value = 1.0
-      w.value = 5.0
-      a.generate()
-      a.value should equal(8.3)
-    }
-
-    "convert to the correct string" in {
-      val u = Uniform(0.0, 2.0)
-      val v = Constant(1.0)
-      val w = Select(0.5 -> 0.0, 0.5 -> 5.0)
-      val f = (d1: Double, d2: Double, d3: Double) => d1 + d2 + d3 + 1.0
-      ApplyC(u, v, w)(f).toString should equal(
-        "Apply(" + u + ", " + v + ", " + w + ", " + f + ")")
-    }
-  }
-
 
   "An Apply with four arguments" should {
     "have value equal to its function applied to its arguments" in {
@@ -443,33 +380,6 @@ class ElementsTest extends WordSpec with Matchers {
       val x = Constant(-2.0)
       val f = (d1: Double, d2: Double, d3: Double, d4: Double) => d1 + d2 + d3 + d4 + 1.0
       Apply(u, v, w, x, f).toString should equal(
-        "Apply(" + u + ", " + v + ", " + w + ", " + x + ", " + f + ")")
-    }
-  }
-
-  "An ApplyC with four arguments" should {
-    "have value equal to its function applied to its arguments" in {
-      Universe.createNew()
-      val u = Uniform(0.0, 2.0)
-      val v = Constant(1.0)
-      val w = Select(0.5 -> 0.0, 0.5 -> 5.0)
-      val x = Constant(-2.0)
-      val a = ApplyC(u, v, w, x)(_ + _ + _ + _ + 1.0)
-      u.value = 1.3
-      v.value = 1.0
-      w.value = 5.0
-      x.value = -2.0
-      a.generate()
-      a.value should equal(6.3)
-    }
-
-    "convert to the correct string" in {
-      val u = Uniform(0.0, 2.0)
-      val v = Constant(1.0)
-      val w = Select(0.5 -> 0.0, 0.5 -> 5.0)
-      val x = Constant(-2.0)
-      val f = (d1: Double, d2: Double, d3: Double, d4: Double) => d1 + d2 + d3 + d4 + 1.0
-      ApplyC(u, v, w, x)(f).toString should equal(
         "Apply(" + u + ", " + v + ", " + w + ", " + x + ", " + f + ")")
     }
   }
@@ -504,38 +414,6 @@ class ElementsTest extends WordSpec with Matchers {
       val f =
         (d1: Double, d2: Double, d3: Double, d4: Double, d5: Double) => d1 + d2 + d3 + d4 + d5 + 1.0
       Apply(u, v, w, x, y, f).toString should equal(
-        "Apply(" + u + ", " + v + ", " + w + ", " + x + ", " + y + ", " + f + ")")
-    }
-  }
-
-  "An ApplyC with five arguments" should {
-    "have value equal to its function applied to its arguments" in {
-      Universe.createNew()
-      val u = Uniform(0.0, 2.0)
-      val v = Constant(1.0)
-      val w = Select(0.5 -> 0.0, 0.5 -> 5.0)
-      val x = Constant(-2.0)
-      val y = Constant(0.5)
-      val a =
-        ApplyC(u, v, w, x, y)(_ + _ + _ + _ + _ + 1.0)
-      u.value = 1.3
-      v.value = 1.0
-      w.value = 5.0
-      x.value = -2.0
-      y.value = 0.5
-      a.generate()
-      a.value should equal(6.8)
-    }
-
-    "convert to the correct string" in {
-      val u = Uniform(0.0, 2.0)
-      val v = Constant(1.0)
-      val w = Select(0.5 -> 0.0, 0.5 -> 5.0)
-      val x = Constant(-2.0)
-      val y = Constant(0.5)
-      val f =
-        (d1: Double, d2: Double, d3: Double, d4: Double, d5: Double) => d1 + d2 + d3 + d4 + d5 + 1.0
-      ApplyC(u, v, w, x, y)(f).toString should equal(
         "Apply(" + u + ", " + v + ", " + w + ", " + x + ", " + y + ", " + f + ")")
     }
   }


### PR DESCRIPTION
* Move ApplyC to extension package
* Improve Chain with currying
* Introduce new CPD which uses `PartialFunction` 

New CPD is an improved over existing one. Instead of List of Values, Element pairs it uses PartialFunctions. This enables compiler catching all cases for CPD as compiler warnings. Even further this makes RichCPD obsolete becuase one can leverage Scala's Pattern Guards instead of `OneOf` , `NoneOf` and `*`  
